### PR TITLE
Add individual track download (closes #100)

### DIFF
--- a/src/components/DownloadButton.tsx
+++ b/src/components/DownloadButton.tsx
@@ -1,11 +1,15 @@
 /**
- * Self-contained download button for album/playlist detail headers.
+ * Self-contained download button for album/playlist/song contexts.
  *
  * Subscribes directly to musicCacheStore and useDownloadStatus so it
  * manages its own re-renders. This avoids the parent screen needing
  * to pass progress via navigation.setOptions — which previously
  * remounted the CircularProgress on every update, losing animation
  * state and causing jumps.
+ *
+ * For `type === 'song'`, the caller must supply an `onDownload` override
+ * because the component only holds the song ID, not the full Child object
+ * required by enqueueSongDownload.
  */
 
 import { Ionicons } from '@expo/vector-icons';
@@ -26,9 +30,9 @@ import { musicCacheStore } from '../store/musicCacheStore';
 
 interface DownloadButtonProps {
   itemId: string;
-  type: 'album' | 'playlist';
+  type: 'album' | 'playlist' | 'song';
   size?: number;
-  /** Override the default enqueue action (e.g. for starred songs). */
+  /** Override the default enqueue action (required when type is 'song'). */
   onDownload?: () => void;
   /** Override the default delete action (e.g. for starred songs). */
   onDelete?: () => void;
@@ -81,7 +85,8 @@ export const DownloadButton = memo(function DownloadButton({
     } else {
       if (onDownload) onDownload();
       else if (type === 'album') enqueueAlbumDownload(itemId);
-      else enqueuePlaylistDownload(itemId);
+      else if (type === 'playlist') enqueuePlaylistDownload(itemId);
+      // type === 'song' without onDownload: no-op (caller must provide onDownload)
     }
   }, [itemId, type, downloadStatus, onDownload, onDelete]);
 

--- a/src/components/MoreOptionsSheet.tsx
+++ b/src/components/MoreOptionsSheet.tsx
@@ -2,7 +2,7 @@
  * MoreOptionsSheet – unified bottom sheet for all entity types.
  *
  * Reads from `moreOptionsStore` and renders entity-specific options:
- *   - Song/Track: Favorite, Add to Playlist, Play More Like This, Add to Queue, Go to Album, Go to Artist, Track Details
+ *   - Song/Track: Favorite, Add to Playlist, Play More Like This, Add to Queue, Go to Album, Go to Artist, Track Details, Download
  *   - Album: Favorite, Add to Queue, Go to Artist, Album Details
  *   - Artist: Favorite, Save Top Songs Playlist, Play Similar Artists
  *   - Playlist: Add to Queue
@@ -41,6 +41,7 @@ import {
   cancelDownload,
   enqueueAlbumDownload,
   enqueuePlaylistDownload,
+  enqueueSongDownload,
   playMoreByArtist,
   playMoreLikeThis,
   playSimilarArtistsMix,
@@ -145,7 +146,7 @@ function canShare(entity: MoreOptionsEntity): boolean {
 }
 
 function canDownload(entity: MoreOptionsEntity): boolean {
-  return entity.type === 'album' || entity.type === 'playlist';
+  return entity.type === 'album' || entity.type === 'playlist' || entity.type === 'song';
 }
 
 function canAddToPlaylist(entity: MoreOptionsEntity): boolean {
@@ -201,8 +202,8 @@ export function MoreOptionsSheet() {
   const starred = useIsStarred(starType, entity?.item.id ?? '');
   const entityRating = useRating(entity?.item.id ?? '', getEntityUserRating(entity));
 
-  const downloadType: 'album' | 'playlist' =
-    entity?.type === 'playlist' ? 'playlist' : 'album';
+  const downloadType: 'song' | 'album' | 'playlist' =
+    entity?.type === 'song' ? 'song' : entity?.type === 'playlist' ? 'playlist' : 'album';
   const downloadStatus: DownloadStatus = useDownloadStatus(
     downloadType,
     entity && canDownload(entity) ? entity.item.id : '',
@@ -396,7 +397,9 @@ export function MoreOptionsSheet() {
         );
         if (queueItem) cancelDownload(queueItem.queueId);
       } else {
-        if (entity.type === 'album') {
+        if (entity.type === 'song') {
+          await enqueueSongDownload(entity.item as Child);
+        } else if (entity.type === 'album') {
           await enqueueAlbumDownload(entity.item.id);
         } else {
           await enqueuePlaylistDownload(entity.item.id);

--- a/src/screens/__tests__/player-view.test.tsx
+++ b/src/screens/__tests__/player-view.test.tsx
@@ -169,7 +169,15 @@ jest.mock('../../services/playerService', () => ({
 
 jest.mock('../../services/moreOptionsService', () => ({
   toggleStar: jest.fn(),
+  enqueueSongDownload: jest.fn(),
 }));
+
+jest.mock('../../components/DownloadButton', () => {
+  const { View } = require('react-native');
+  return {
+    DownloadButton: () => <View testID="download-button" />,
+  };
+});
 
 jest.mock('../../utils/formatters', () => ({
   sanitizeBiographyText: jest.fn((text: string) => text),

--- a/src/screens/music-cache-browser.tsx
+++ b/src/screens/music-cache-browser.tsx
@@ -176,7 +176,7 @@ const CacheRow = memo(function CacheRow({
               </Text>
             )}
             <Text style={[styles.rowMeta, { color: colors.textSecondary }]}>
-              {item.type === 'album' ? t('album') : t('playlist')} · {trackLabel} · {formatBytes(item.totalBytes)}
+              {item.type === 'album' ? t('album') : item.type === 'song' ? t('song') : t('playlist')} · {trackLabel} · {formatBytes(item.totalBytes)}
             </Text>
           </View>
           <Ionicons

--- a/src/screens/player-view.tsx
+++ b/src/screens/player-view.tsx
@@ -37,6 +37,7 @@ import { useTranslation } from 'react-i18next';
 
 import { AlbumInfoContent } from '../components/AlbumInfoContent';
 import { CachedImage } from '../components/CachedImage';
+import { DownloadButton } from '../components/DownloadButton';
 import { EmptyState } from '../components/EmptyState';
 import { MarqueeText } from '../components/MarqueeText';
 import { MoreOptionsButton } from '../components/MoreOptionsButton';
@@ -57,7 +58,7 @@ import { useIsStarred } from '../hooks/useIsStarred';
 import { useTheme } from '../hooks/useTheme';
 import { ThemedAlert } from '../components/ThemedAlert';
 import { useThemedAlert } from '../hooks/useThemedAlert';
-import { toggleStar } from '../services/moreOptionsService';
+import { enqueueSongDownload, toggleStar } from '../services/moreOptionsService';
 import { offlineModeStore } from '../store/offlineModeStore';
 import {
   clearQueue,
@@ -491,6 +492,34 @@ const FavoriteButton = memo(function FavoriteButton({
 });
 
 /* ------------------------------------------------------------------ */
+/*  Download button                                                    */
+/* ------------------------------------------------------------------ */
+
+const PlayerDownloadButton = memo(function PlayerDownloadButton({
+  track,
+}: {
+  track: Child;
+}) {
+  const offlineMode = offlineModeStore((s) => s.offlineMode);
+
+  const handleDownload = useCallback(() => {
+    if (offlineMode) return;
+    enqueueSongDownload(track);
+  }, [track, offlineMode]);
+
+  return (
+    <View style={styles.downloadButton}>
+      <DownloadButton
+        itemId={track.id}
+        type="song"
+        size={24}
+        onDownload={handleDownload}
+      />
+    </View>
+  );
+});
+
+/* ------------------------------------------------------------------ */
 /*  Player content (hero, controls) — "Player" tab                     */
 /* ------------------------------------------------------------------ */
 
@@ -590,6 +619,7 @@ const PlayerContent = memo(function PlayerContent({
             </Text>
           </View>
           <FavoriteButton trackId={currentTrack.id} colors={colors} />
+          <PlayerDownloadButton track={currentTrack} />
         </View>
       </View>
 
@@ -928,6 +958,10 @@ const styles = StyleSheet.create({
   },
   favoriteButton: {
     paddingLeft: 12,
+    paddingVertical: 4,
+  },
+  downloadButton: {
+    paddingLeft: 4,
     paddingVertical: 4,
   },
   progressSection: {

--- a/src/services/__tests__/musicCacheService.test.ts
+++ b/src/services/__tests__/musicCacheService.test.ts
@@ -158,6 +158,7 @@ import {
   getTrackQueueStatus,
   enqueueAlbumDownload,
   enqueuePlaylistDownload,
+  enqueueSongDownload,
   enqueueStarredSongsDownload,
   deleteCachedItem,
   removeCachedPlaylistTrack,
@@ -907,6 +908,71 @@ describe('enqueuePlaylistDownload', () => {
     expect(queue[0].itemId).toBe('pl-1');
     expect(queue[0].type).toBe('playlist');
     expect(queue[0].totalTracks).toBe(3);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  enqueueSongDownload                                                */
+/* ------------------------------------------------------------------ */
+
+describe('enqueueSongDownload', () => {
+  it('skips if song is already cached', async () => {
+    musicCacheStore.setState({
+      cachedItems: {
+        'song-1': { itemId: 'song-1', type: 'song', name: 'Test Song', tracks: [], totalBytes: 0 },
+      },
+    } as any);
+
+    await enqueueSongDownload(makeChild('song-1'));
+
+    expect(musicCacheStore.getState().downloadQueue).toHaveLength(0);
+  });
+
+  it('skips if song is already in download queue', async () => {
+    musicCacheStore.setState({
+      downloadQueue: [
+        { queueId: 'q1', itemId: 'song-1', status: 'queued', tracks: [], totalTracks: 0, completedTracks: 0, addedAt: Date.now() },
+      ],
+    } as any);
+
+    await enqueueSongDownload(makeChild('song-1'));
+
+    expect(musicCacheStore.getState().downloadQueue).toHaveLength(1);
+  });
+
+  it('enqueues a single song', async () => {
+    const song = makeChild('song-1', { title: 'My Track', artist: 'My Artist', coverArt: 'cover-1' });
+
+    await enqueueSongDownload(song);
+
+    const queue = musicCacheStore.getState().downloadQueue;
+    expect(queue).toHaveLength(1);
+    expect(queue[0].itemId).toBe('song-1');
+    expect(queue[0].type).toBe('song');
+    expect(queue[0].name).toBe('My Track');
+    expect(queue[0].artist).toBe('My Artist');
+    expect(queue[0].totalTracks).toBe(1);
+    expect(queue[0].tracks).toHaveLength(1);
+  });
+
+  it('caches cover art for the song', async () => {
+    const song = makeChild('song-1', { coverArt: 'song-cover' });
+
+    await enqueueSongDownload(song);
+
+    expect(cacheAllSizes).toHaveBeenCalledWith('song-cover');
+    expect(cacheEntityCoverArt).toHaveBeenCalledWith(
+      expect.arrayContaining([expect.objectContaining({ coverArt: 'song-cover' })]),
+    );
+  });
+
+  it('handles missing title gracefully', async () => {
+    const song = makeChild('song-1', { title: undefined });
+
+    await enqueueSongDownload(song);
+
+    const queue = musicCacheStore.getState().downloadQueue;
+    expect(queue[0].name).toBe('Unknown');
   });
 });
 

--- a/src/services/moreOptionsService.ts
+++ b/src/services/moreOptionsService.ts
@@ -376,6 +376,6 @@ export async function playAllByArtist(
 /*  Download management                                                */
 /* ------------------------------------------------------------------ */
 
-export { enqueueAlbumDownload, enqueuePlaylistDownload } from './musicCacheService';
+export { enqueueAlbumDownload, enqueuePlaylistDownload, enqueueSongDownload } from './musicCacheService';
 
 export { deleteCachedItem as removeDownload, cancelDownload } from './musicCacheService';

--- a/src/services/musicCacheService.ts
+++ b/src/services/musicCacheService.ts
@@ -418,6 +418,35 @@ export async function enqueuePlaylistDownload(playlistId: string): Promise<void>
   processQueue();
 }
 
+/**
+ * Cache a single song for offline playback. Uses the song's own ID as the
+ * itemId so that `useDownloadStatus('song', id)` resolves correctly once the
+ * file is on disk.
+ */
+export async function enqueueSongDownload(song: Child): Promise<void> {
+  const state = musicCacheStore.getState();
+  if (song.id in state.cachedItems) return;
+  if (state.downloadQueue.some((q) => q.itemId === song.id)) return;
+
+  await ensureCoverArtAuth();
+  if (song.coverArt) {
+    cacheAllSizes(song.coverArt).catch(() => { /* non-critical */ });
+  }
+  cacheTrackCoverArt([song]);
+
+  musicCacheStore.getState().enqueue({
+    itemId: song.id,
+    type: 'song',
+    name: song.title ?? 'Unknown',
+    artist: song.artist,
+    coverArtId: song.coverArt,
+    totalTracks: 1,
+    tracks: [song],
+  });
+
+  processQueue();
+}
+
 /* ------------------------------------------------------------------ */
 /*  Queue processing                                                   */
 /* ------------------------------------------------------------------ */
@@ -593,7 +622,7 @@ async function downloadItem(queueItem: DownloadQueueItemSnapshot, myId: number):
 type DownloadQueueItemSnapshot = Readonly<{
   queueId: string;
   itemId: string;
-  type: 'album' | 'playlist';
+  type: 'album' | 'playlist' | 'song';
   name: string;
   artist?: string;
   coverArtId?: string;
@@ -714,8 +743,20 @@ export async function redownloadItem(itemId: string): Promise<void> {
 
   if (cached.type === 'album') {
     await enqueueAlbumDownload(itemId);
-  } else {
+  } else if (cached.type === 'playlist') {
     await enqueuePlaylistDownload(itemId);
+  } else {
+    // 'song' – reconstruct a minimal Child from cached metadata and re-enqueue
+    if (cached.tracks.length > 0) {
+      const t = cached.tracks[0];
+      await enqueueSongDownload({
+        id: t.id,
+        title: t.title,
+        artist: t.artist,
+        coverArt: t.coverArt,
+        isDir: false,
+      } as Child);
+    }
   }
 }
 

--- a/src/store/musicCacheStore.ts
+++ b/src/store/musicCacheStore.ts
@@ -33,7 +33,7 @@ export interface CachedTrack {
 
 export interface CachedMusicItem {
   itemId: string;
-  type: 'album' | 'playlist';
+  type: 'album' | 'playlist' | 'song';
   name: string;
   artist?: string;
   coverArtId?: string;
@@ -51,7 +51,7 @@ export type DownloadItemStatus =
 export interface DownloadQueueItem {
   queueId: string;
   itemId: string;
-  type: 'album' | 'playlist';
+  type: 'album' | 'playlist' | 'song';
   name: string;
   artist?: string;
   coverArtId?: string;


### PR DESCRIPTION
Allows users to download single songs for offline playback.

**Changes:**
- Long-press any track → more options sheet now shows Download/Remove Download
- Now Playing screen shows a download button next to the ♥ icon
- Download status indicator (downloaded icon) already worked per-song via `useDownloadStatus('song', id)` — no changes needed in `TrackRow`/`SongRow`

**Implementation:**
- New `enqueueSongDownload(song)` in `musicCacheService` — stores the track under its own ID as itemId
- `DownloadButton` extended to accept `type: 'song'`
- `MoreOptionsSheet` `canDownload()` now includes songs

Closes #100