### PR TITLE
Show if song is in playlist

### DIFF
--- a/src/components/AddToPlaylistSheet.tsx
+++ b/src/components/AddToPlaylistSheet.tsx
@@ -18,6 +18,8 @@ import Animated, {
   Easing,
 } from 'react-native-reanimated';
 import { useTranslation } from 'react-i18next';
+import i18n from '../i18n/i18n';
+
 
 import { BottomSheet } from './BottomSheet';
 import { CachedImage } from './CachedImage';
@@ -36,8 +38,9 @@ import { musicCacheStore } from '../store/musicCacheStore';
 import { playlistDetailStore } from '../store/playlistDetailStore';
 import { playlistLibraryStore } from '../store/playlistLibraryStore';
 import { processingOverlayStore } from '../store/processingOverlayStore';
+import { layoutPreferencesStore } from '@/store/layoutPreferencesStore';
 
-import type { Playlist } from '../services/subsonicService';
+import type { Playlist, PlaylistWithSongs } from '../services/subsonicService';
 
 const CONTENT_DELAY_MS = 750;
 const CONTENT_ANIMATE_DURATION = 1000;
@@ -86,6 +89,7 @@ export function AddToPlaylistSheet() {
   const playlists = playlistLibraryStore((s) => s.playlists);
   const playlistsLoading = playlistLibraryStore((s) => s.loading);
   const playlistsFetchError = playlistLibraryStore((s) => s.error);
+  const showSongInPlaylist = layoutPreferencesStore((s) => s.showSongInPlaylist);
 
   const { colors } = useTheme();
   const { t } = useTranslation();
@@ -111,7 +115,11 @@ export function AddToPlaylistSheet() {
       animatedHeight.value = SPINNER_HEIGHT;
       contentOpacity.value = 0;
       const timer = setTimeout(() => {
-        playlistLibraryStore.getState().fetchAllPlaylists();
+        if (showSongInPlaylist === "show") {
+          playlistLibraryStore.getState().fetchAllPlaylistsWithSongs();
+        } else {
+          playlistLibraryStore.getState().fetchAllPlaylists();
+        }
         setPhase('measuring');
       }, CONTENT_DELAY_MS);
       return () => clearTimeout(timer);
@@ -184,8 +192,11 @@ export function AddToPlaylistSheet() {
             syncCachedItemTracks(playlist.id, updated.entry ?? []);
           }
         }
-
-        playlistLibraryStore.getState().fetchAllPlaylists();
+        if (showSongInPlaylist === "show") {
+          playlistLibraryStore.getState().fetchAllPlaylistsWithSongs();
+        } else {
+          playlistLibraryStore.getState().fetchAllPlaylists();
+        }
         processingOverlayStore.getState().showSuccess(t('addedToPlaylist'));
       } catch {
         processingOverlayStore.getState().showError(t('failedToAddToPlaylist'));
@@ -212,7 +223,11 @@ export function AddToPlaylistSheet() {
       if (!success) throw new Error('API returned false');
 
       handleClose();
-      playlistLibraryStore.getState().fetchAllPlaylists();
+      if (showSongInPlaylist === "show") {
+        playlistLibraryStore.getState().fetchAllPlaylistsWithSongs();
+      } else {
+        playlistLibraryStore.getState().fetchAllPlaylists();
+      }
       processingOverlayStore.getState().show(t('creating'));
       processingOverlayStore.getState().showSuccess(t('playlistCreated'));
     } catch {
@@ -255,6 +270,22 @@ export function AddToPlaylistSheet() {
   const subtitle = target ? getSubtitleText(target, t) : '';
   const coverArtId = target ? getTargetCoverArt(target) : undefined;
 
+  const numberOfMatch = (playlist: Playlist | PlaylistWithSongs) => {
+    if (!playlist) return 0;
+    if (!(playlist as PlaylistWithSongs)?.entry) return 0;
+
+    const playlistWithSongs = playlist as PlaylistWithSongs;
+
+    if (target?.type === 'song') {
+      const matchCount = playlistWithSongs.entry?.filter((current_entry) => target.item.id === current_entry.id).length || 0;
+      return matchCount;
+    }
+    else if (target?.type === "album") {
+      return 0;
+    }
+
+    return 0;
+  }
   return (
     <BottomSheet visible={visible} onClose={handleClose} maxHeight="70%">
       <View style={styles.header}>
@@ -285,120 +316,129 @@ export function AddToPlaylistSheet() {
             ]}
             onLayout={phase === 'measuring' ? handleContentLayout : undefined}
           >
-          {mode === 'pick' ? (
-            <ScrollView
-            style={styles.listContainer}
-            contentContainerStyle={styles.listContent}
-            bounces={false}
-            showsVerticalScrollIndicator={false}
-          >
-            {/* New Playlist row */}
-            <Pressable
-              onPress={handleShowCreate}
-              style={({ pressed }) => [
-                styles.playlistRow,
-                pressed && styles.rowPressed,
-              ]}
-            >
-              <Ionicons name="add-circle-outline" size={24} color={colors.primary} />
-              <Text style={[styles.newPlaylistLabel, dynamicStyles.newPlaylistLabel]}>
-                {t('newPlaylist')}
-              </Text>
-            </Pressable>
-
-            <View style={[styles.separator, dynamicStyles.separator]} />
-
-            {playlists.map((playlist) => (
-              <Pressable
-                key={playlist.id}
-                onPress={() => handleSelectPlaylist(playlist)}
-                disabled={busy}
-                style={({ pressed }) => [
-                  styles.playlistRow,
-                  pressed && styles.rowPressed,
-                ]}
+            {mode === 'pick' ? (
+              <ScrollView
+                style={styles.listContainer}
+                contentContainerStyle={styles.listContent}
+                bounces={false}
+                showsVerticalScrollIndicator={false}
               >
-                <Ionicons name="list-outline" size={22} color={colors.textSecondary} />
-                <View style={styles.playlistInfo}>
-                  <Text
-                    style={[styles.playlistName, dynamicStyles.playlistName]}
-                    numberOfLines={1}
+                {/* New Playlist row */}
+                <Pressable
+                  onPress={handleShowCreate}
+                  style={({ pressed }) => [
+                    styles.playlistRow,
+                    pressed && styles.rowPressed,
+                  ]}
+                >
+                  <Ionicons name="add-circle-outline" size={24} color={colors.primary} />
+                  <Text style={[styles.newPlaylistLabel, dynamicStyles.newPlaylistLabel]}>
+                    {t('newPlaylist')}
+                  </Text>
+                </Pressable>
+
+                <View style={[styles.separator, dynamicStyles.separator]} />
+
+                {playlists.map((playlist) => (
+                  <Pressable
+                    key={playlist.id}
+                    onPress={() => handleSelectPlaylist(playlist)}
+                    disabled={busy}
+                    style={({ pressed }) => [
+                      styles.playlistRow,
+                      pressed && styles.rowPressed,
+                    ]}
                   >
-                    {playlist.name}
+                    <Ionicons name="list-outline" size={22} color={colors.textSecondary} />
+                    <View style={styles.playlistInfo}>
+                      <Text
+                        style={[styles.playlistName, dynamicStyles.playlistName]}
+                        numberOfLines={1}
+                      >
+                        {playlist.name}
+                      </Text>
+                      <Text style={[styles.playlistCount, dynamicStyles.playlistCount]}>
+                        {t('trackWithCount', { count: playlist.songCount ?? 0 })}
+                      </Text>
+                    </View>
+                    {numberOfMatch(playlist) > 0 ?
+                      <View>
+
+                        <Text style={[styles.playlistName, dynamicStyles.playlistName]}
+                          numberOfLines={1}>
+                          {i18n.t('numberOfTimesInPlaylist', { count: numberOfMatch(playlist) })}
+                        </Text>
+
+                      </View> : null}
+                  </Pressable>
+                ))}
+
+                {playlists.length === 0 && playlistsLoading && (
+                  <ActivityIndicator style={styles.loadingIndicator} color={colors.textSecondary} />
+                )}
+
+                {playlists.length === 0 && !playlistsLoading && !playlistsFetchError && (
+                  <Text style={[styles.emptyText, dynamicStyles.playlistCount]}>
+                    {t('noPlaylistsYet')}
                   </Text>
-                  <Text style={[styles.playlistCount, dynamicStyles.playlistCount]}>
-                    {t('trackWithCount', { count: playlist.songCount ?? 0 })}
+                )}
+
+                {playlistsFetchError && playlists.length === 0 && !playlistsLoading && (
+                  <Text style={[styles.emptyText, dynamicStyles.errorText]}>
+                    {t('failedToLoadPlaylists')}
                   </Text>
-                </View>
-              </Pressable>
-            ))}
+                )}
 
-            {playlists.length === 0 && playlistsLoading && (
-              <ActivityIndicator style={styles.loadingIndicator} color={colors.textSecondary} />
+                {playlists.length > 0 && playlistsLoading && (
+                  <ActivityIndicator style={styles.loadingIndicator} size="small" color={colors.textSecondary} />
+                )}
+              </ScrollView>
+            ) : (
+              <View style={styles.formSection}>
+                {/* Back arrow */}
+                <Pressable onPress={handleBackToPick} style={styles.backButton}>
+                  <Ionicons name="arrow-back" size={20} color={colors.primary} />
+                  <Text style={[styles.backLabel, { color: colors.primary }]}>{t('back')}</Text>
+                </Pressable>
+
+                <Text style={[styles.label, dynamicStyles.subtitle]}>{t('playlistName')}</Text>
+                <TextInput
+                  style={[styles.input, dynamicStyles.input]}
+                  value={name}
+                  onChangeText={setName}
+                  placeholder={t('enterPlaylistNamePlaceholder')}
+                  placeholderTextColor={colors.textSecondary}
+                  returnKeyType="done"
+                  autoFocus
+                  editable={!busy}
+                  onSubmitEditing={handleCreatePlaylist}
+                />
+
+                {error && (
+                  <Text style={[styles.errorText, dynamicStyles.errorText]}>{error}</Text>
+                )}
+
+                <Pressable
+                  onPress={handleCreatePlaylist}
+                  disabled={busy}
+                  style={({ pressed }) => [
+                    styles.createButton,
+                    dynamicStyles.createButton,
+                    pressed && styles.buttonPressed,
+                    busy && styles.buttonDisabled,
+                  ]}
+                >
+                  {busy ? (
+                    <ActivityIndicator size="small" color="#fff" />
+                  ) : (
+                    <>
+                      <Ionicons name="add-outline" size={18} color="#fff" />
+                      <Text style={styles.createButtonText}>{t('createPlaylist')}</Text>
+                    </>
+                  )}
+                </Pressable>
+              </View>
             )}
-
-            {playlists.length === 0 && !playlistsLoading && !playlistsFetchError && (
-              <Text style={[styles.emptyText, dynamicStyles.playlistCount]}>
-                {t('noPlaylistsYet')}
-              </Text>
-            )}
-
-            {playlistsFetchError && playlists.length === 0 && !playlistsLoading && (
-              <Text style={[styles.emptyText, dynamicStyles.errorText]}>
-                {t('failedToLoadPlaylists')}
-              </Text>
-            )}
-
-            {playlists.length > 0 && playlistsLoading && (
-              <ActivityIndicator style={styles.loadingIndicator} size="small" color={colors.textSecondary} />
-            )}
-          </ScrollView>
-        ) : (
-          <View style={styles.formSection}>
-            {/* Back arrow */}
-            <Pressable onPress={handleBackToPick} style={styles.backButton}>
-              <Ionicons name="arrow-back" size={20} color={colors.primary} />
-              <Text style={[styles.backLabel, { color: colors.primary }]}>{t('back')}</Text>
-            </Pressable>
-
-            <Text style={[styles.label, dynamicStyles.subtitle]}>{t('playlistName')}</Text>
-            <TextInput
-              style={[styles.input, dynamicStyles.input]}
-              value={name}
-              onChangeText={setName}
-              placeholder={t('enterPlaylistNamePlaceholder')}
-              placeholderTextColor={colors.textSecondary}
-              returnKeyType="done"
-              autoFocus
-              editable={!busy}
-              onSubmitEditing={handleCreatePlaylist}
-            />
-
-            {error && (
-              <Text style={[styles.errorText, dynamicStyles.errorText]}>{error}</Text>
-            )}
-
-            <Pressable
-              onPress={handleCreatePlaylist}
-              disabled={busy}
-              style={({ pressed }) => [
-                styles.createButton,
-                dynamicStyles.createButton,
-                pressed && styles.buttonPressed,
-                busy && styles.buttonDisabled,
-              ]}
-            >
-              {busy ? (
-                <ActivityIndicator size="small" color="#fff" />
-              ) : (
-                <>
-                  <Ionicons name="add-outline" size={18} color="#fff" />
-                  <Text style={styles.createButtonText}>{t('createPlaylist')}</Text>
-                </>
-              )}
-            </Pressable>
-          </View>
-          )}
           </Animated.View>
         )}
       </Animated.View>
@@ -457,8 +497,7 @@ const styles = StyleSheet.create({
     minWidth: 0,
   },
   playlistName: {
-    fontSize: 16,
-    fontWeight: '500',
+    fontSize: 14,
   },
   playlistCount: {
     fontSize: 14,

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -910,5 +910,10 @@
   "storageNoLimit": "Kein Limit",
   "storageLegendImages": "Bilder",
   "storageLegendMusic": "Musik",
-  "storageLegendFree": "Verfügbar"
+  "storageLegendFree": "Verfügbar",
+  "showSongInPlaylistOption": "Show if song is in playlist",
+  "showSongInPlaylist": "Show",
+  "hideSongInPlaylist": "Hide",
+  "numberOfTimesInPlaylist": "Times present : {{count}}",
+  "failedToLoadPlaylistsEntries": "Failed To Load Playlists Entries"
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -929,5 +929,10 @@
   "storageNoLimit": "No limit",
   "storageLegendImages": "Images",
   "storageLegendMusic": "Music",
-  "storageLegendFree": "Free"
+  "storageLegendFree": "Free",
+  "showSongInPlaylistOption": "Show if song is in playlist",
+  "showSongInPlaylist": "Show",
+  "hideSongInPlaylist": "Hide",
+  "numberOfTimesInPlaylist": "Times present : {{count}}",
+  "failedToLoadPlaylistsEntries": "Failed To Load Playlists Entries"
 }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -910,5 +910,10 @@
   "storageNoLimit": "Sin límite",
   "storageLegendImages": "Imágenes",
   "storageLegendMusic": "Música",
-  "storageLegendFree": "Disponible"
+  "storageLegendFree": "Disponible",
+  "showSongInPlaylistOption": "Show if song is in playlist",
+  "showSongInPlaylist": "Show",
+  "hideSongInPlaylist": "Hide",
+  "numberOfTimesInPlaylist": "Times present : {{count}}",
+  "failedToLoadPlaylistsEntries": "Failed To Load Playlists Entries"
 }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -910,5 +910,10 @@
   "storageNoLimit": "Sans limite",
   "storageLegendImages": "Images",
   "storageLegendMusic": "Musique",
-  "storageLegendFree": "Disponible"
+  "storageLegendFree": "Disponible",
+  "showSongInPlaylistOption" : "Afficher si une musique est dans une playlist",
+  "showSongInPlaylist": "Afficher",
+  "hideSongInPlaylist": "Cacher",
+  "numberOfTimesInPlaylist": "Présente {{count}} fois",
+  "failedToLoadPlaylistsEntries": "Impossible de charger les musiques des playlists"
 }

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -910,5 +910,10 @@
   "storageNoLimit": "No limit",
   "storageLegendImages": "Images",
   "storageLegendMusic": "Music",
-  "storageLegendFree": "Free"
+  "storageLegendFree": "Free",
+  "showSongInPlaylistOption": "Show if song is in playlist",
+  "showSongInPlaylist": "Show",
+  "hideSongInPlaylist": "Hide",
+  "numberOfTimesInPlaylist": "Times present : {{count}}",
+  "failedToLoadPlaylistsEntries": "Failed To Load Playlists Entries"
 }

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -910,5 +910,10 @@
   "storageNoLimit": "Nessun limite",
   "storageLegendImages": "Immagini",
   "storageLegendMusic": "Musica",
-  "storageLegendFree": "Disponibile"
+  "storageLegendFree": "Disponibile",
+  "showSongInPlaylistOption": "Show if song is in playlist",
+  "showSongInPlaylist": "Show",
+  "hideSongInPlaylist": "Hide",
+  "numberOfTimesInPlaylist": "Times present : {{count}}",
+  "failedToLoadPlaylistsEntries": "Failed To Load Playlists Entries"
 }

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -910,5 +910,10 @@
   "storageNoLimit": "No limit",
   "storageLegendImages": "Images",
   "storageLegendMusic": "Music",
-  "storageLegendFree": "Free"
+  "storageLegendFree": "Free",
+  "showSongInPlaylistOption": "Show if song is in playlist",
+  "showSongInPlaylist": "Show",
+  "hideSongInPlaylist": "Hide",
+  "numberOfTimesInPlaylist": "Times present : {{count}}",
+  "failedToLoadPlaylistsEntries": "Failed To Load Playlists Entries"
 }

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -910,5 +910,10 @@
   "storageNoLimit": "No limit",
   "storageLegendImages": "Images",
   "storageLegendMusic": "Music",
-  "storageLegendFree": "Free"
+  "storageLegendFree": "Free",
+  "showSongInPlaylistOption": "Show if song is in playlist",
+  "showSongInPlaylist": "Show",
+  "hideSongInPlaylist": "Hide",
+  "numberOfTimesInPlaylist": "Times present : {{count}}",
+  "failedToLoadPlaylistsEntries": "Failed To Load Playlists Entries"
 }

--- a/src/i18n/locales/ms.json
+++ b/src/i18n/locales/ms.json
@@ -910,5 +910,10 @@
   "storageNoLimit": "No limit",
   "storageLegendImages": "Images",
   "storageLegendMusic": "Music",
-  "storageLegendFree": "Free"
+  "storageLegendFree": "Free",
+  "showSongInPlaylistOption": "Show if song is in playlist",
+  "showSongInPlaylist": "Show",
+  "hideSongInPlaylist": "Hide",
+  "numberOfTimesInPlaylist": "Times present : {{count}}",
+  "failedToLoadPlaylistsEntries": "Failed To Load Playlists Entries"
 }

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -910,5 +910,10 @@
   "storageNoLimit": "No limit",
   "storageLegendImages": "Images",
   "storageLegendMusic": "Music",
-  "storageLegendFree": "Free"
+  "storageLegendFree": "Free",
+  "showSongInPlaylistOption": "Show if song is in playlist",
+  "showSongInPlaylist": "Show",
+  "hideSongInPlaylist": "Hide",
+  "numberOfTimesInPlaylist": "Times present : {{count}}",
+  "failedToLoadPlaylistsEntries": "Failed To Load Playlists Entries"
 }

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -910,5 +910,10 @@
   "storageNoLimit": "Без ограничений",
   "storageLegendImages": "Изображения",
   "storageLegendMusic": "Музыка",
-  "storageLegendFree": "Свободно"
+  "storageLegendFree": "Свободно",
+  "showSongInPlaylistOption": "Show if song is in playlist",
+  "showSongInPlaylist": "Show",
+  "hideSongInPlaylist": "Hide",
+  "numberOfTimesInPlaylist": "Times present : {{count}}",
+  "failedToLoadPlaylistsEntries": "Failed To Load Playlists Entries"
 }

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -910,5 +910,10 @@
   "storageNoLimit": "No limit",
   "storageLegendImages": "Images",
   "storageLegendMusic": "Music",
-  "storageLegendFree": "Free"
+  "storageLegendFree": "Free",
+  "showSongInPlaylistOption": "Show if song is in playlist",
+  "showSongInPlaylist": "Show",
+  "hideSongInPlaylist": "Hide",
+  "numberOfTimesInPlaylist": "Times present : {{count}}",
+  "failedToLoadPlaylistsEntries": "Failed To Load Playlists Entries"
 }

--- a/src/i18n/locales/zh-Hans.json
+++ b/src/i18n/locales/zh-Hans.json
@@ -910,5 +910,10 @@
   "storageNoLimit": "无限制",
   "storageLegendImages": "图像",
   "storageLegendMusic": "音乐",
-  "storageLegendFree": "剩余"
+  "storageLegendFree": "剩余",
+  "showSongInPlaylistOption": "Show if song is in playlist",
+  "showSongInPlaylist": "Show",
+  "hideSongInPlaylist": "Hide",
+  "numberOfTimesInPlaylist": "Times present : {{count}}",
+  "failedToLoadPlaylistsEntries": "Failed To Load Playlists Entries"
 }

--- a/src/i18n/locales/zh-Hant.json
+++ b/src/i18n/locales/zh-Hant.json
@@ -910,5 +910,10 @@
   "storageNoLimit": "無限制",
   "storageLegendImages": "圖像",
   "storageLegendMusic": "音樂",
-  "storageLegendFree": "剩餘"
+  "storageLegendFree": "剩餘",
+  "showSongInPlaylistOption": "Show if song is in playlist",
+  "showSongInPlaylist": "Show",
+  "hideSongInPlaylist": "Hide",
+  "numberOfTimesInPlaylist": "Times present : {{count}}",
+  "failedToLoadPlaylistsEntries": "Failed To Load Playlists Entries"
 }

--- a/src/screens/settings-appearance.tsx
+++ b/src/screens/settings-appearance.tsx
@@ -13,6 +13,7 @@ import type { ThemePreference } from '../store/themeStore';
 import { DEFAULT_PRIMARY_COLOR } from '../store/themeStore';
 import {
   layoutPreferencesStore,
+  ShowSongInPlaylist,
   type AlbumSortOrder,
   type ArtistAlbumSortOrder,
   type DateFormat,
@@ -47,6 +48,8 @@ const ALBUM_SORT_OPTIONS: { value: AlbumSortOrder; labelKey: string }[] = [
   { value: 'title', labelKey: 'sortAlbumTitle' },
 ];
 
+
+
 const ARTIST_ALBUM_SORT_OPTIONS: { value: ArtistAlbumSortOrder; labelKey: string }[] = [
   { value: 'newest', labelKey: 'sortNewestFirst' },
   { value: 'oldest', labelKey: 'sortOldestFirst' },
@@ -75,6 +78,10 @@ const ACCENT_COLORS: { labelKey: string; hex: string }[] = [
   { labelKey: 'colorYellow', hex: '#FFD600' },
 ];
 
+const SHOW_SONG_IN_PLAYLIST_OPTIONS: { value: ShowSongInPlaylist; labelKey: string }[] = [
+  { value: 'show', labelKey: 'showSongInPlaylist' },
+  { value: 'hide', labelKey: 'hideSongInPlaylist' },
+];
 export function SettingsAppearanceScreen() {
   const { t } = useTranslation();
   const { colors, preference, primaryColor, setThemePreference, setPrimaryColor } = useTheme();
@@ -85,8 +92,11 @@ export function SettingsAppearanceScreen() {
   const [artistAlbumSortOpen, setArtistAlbumSortOpen] = useState(false);
   const [dateFormatOpen, setDateFormatOpen] = useState(false);
   const [listLengthOpen, setListLengthOpen] = useState(false);
+  const [showSongInPlaylistOpen, setShowSongInPlaylistOpen] = useState(false);
+
   const activeAccentMatch = ACCENT_COLORS.find((c) => c.hex === activePrimary);
   const activeAccentLabel = activeAccentMatch ? t(activeAccentMatch.labelKey) : t('custom');
+
 
   const handleAccentSelect = useCallback(
     (hex: string) => {
@@ -177,6 +187,9 @@ export function SettingsAppearanceScreen() {
     favAlbumLayout: setFavAlbumLayout,
     favArtistLayout: setFavArtistLayout,
   };
+
+  const showSongInPlaylist = layoutPreferencesStore((s) => s.showSongInPlaylist);
+  const setShowSongInPlaylist = layoutPreferencesStore((s) => s.setShowSongInPlaylist);
 
   const dynamicStyles = useMemo(
     () =>
@@ -611,6 +624,56 @@ export function SettingsAppearanceScreen() {
               </View>
             );
           })}
+        </View>
+      </View>
+
+      <View style={settingsStyles.section}>
+        <Text style={[settingsStyles.sectionTitle, dynamicStyles.sectionTitle]}>{t('showSongInPlaylistOption')}</Text>
+        <View style={[styles.accentDropdown, { backgroundColor: colors.card }]}>
+          <Pressable
+            onPress={() => setShowSongInPlaylistOpen((prev) => !prev)}
+            style={({ pressed }) => [
+              styles.accentHeader,
+              pressed && settingsStyles.pressed,
+            ]}
+          >
+            <Text style={[styles.chipLabel, { color: colors.textPrimary }]}>
+              {t(SHOW_SONG_IN_PLAYLIST_OPTIONS.find((o) => o.value === showSongInPlaylist)!.labelKey)}{' '}
+            </Text>
+            <Ionicons
+              name={showSongInPlaylistOpen ? 'chevron-up' : 'chevron-down'}
+              size={20}
+              color={colors.textSecondary}
+            />
+          </Pressable>
+          {showSongInPlaylistOpen && (
+            <View style={[styles.accentList, { borderTopColor: colors.border }]}>
+              {SHOW_SONG_IN_PLAYLIST_OPTIONS.map((opt) => {
+                const isActive = showSongInPlaylist === opt.value;
+                return (
+                  <Pressable
+                    key={opt.value}
+                    onPress={() => {
+                      setShowSongInPlaylist(opt.value);
+                      setShowSongInPlaylistOpen(false);
+                    }}
+                    style={({ pressed }) => [
+                      styles.accentOption,
+                      { borderBottomColor: colors.border },
+                      pressed && settingsStyles.pressed,
+                    ]}
+                  >
+                    <Text style={[styles.chipLabel, { color: colors.textPrimary }]}>
+                      {t(opt.labelKey)}{' '}
+                    </Text>
+                    {isActive && (
+                      <Ionicons name="checkmark" size={20} color={colors.primary} />
+                    )}
+                  </Pressable>
+                );
+              })}
+            </View>
+          )}
         </View>
       </View>
 

--- a/src/store/__tests__/playlistLibraryStore.test.ts
+++ b/src/store/__tests__/playlistLibraryStore.test.ts
@@ -1,10 +1,12 @@
 jest.mock('../persistence/kvStorage', () => require('../persistence/__mocks__/kvStorage'));
 jest.mock('../../services/subsonicService');
 
-import { ensureCoverArtAuth, getAllPlaylists } from '../../services/subsonicService';
+import { ensureCoverArtAuth, getAllPlaylists, getPlaylist, PlaylistWithSongs } from '../../services/subsonicService';
 import { playlistLibraryStore } from '../playlistLibraryStore';
 
 const mockGetAllPlaylists = getAllPlaylists as jest.MockedFunction<typeof getAllPlaylists>;
+const mockGetPlaylist = getPlaylist as jest.MockedFunction<typeof getPlaylist>;
+
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -12,6 +14,8 @@ beforeEach(() => {
 });
 
 const makePlaylist = (id: string, name: string) => ({ id, name } as any);
+const makePlaylistWithSongs = (id: string, name: string, entry: { id: string }[]) => ({ id, name, entry } as any);
+
 
 describe('playlistLibraryStore', () => {
   describe('fetchAllPlaylists', () => {
@@ -25,6 +29,27 @@ describe('playlistLibraryStore', () => {
       expect(state.playlists).toHaveLength(1);
       expect(state.loading).toBe(false);
       expect(state.lastFetchedAt).toBeGreaterThan(0);
+    });
+
+    it('fetches and stores playlists with entries', async () => {
+      mockGetAllPlaylists.mockResolvedValue([makePlaylist('p1', 'Chill')]);
+      mockGetPlaylist.mockResolvedValue(makePlaylistWithSongs('p1', 'Chill', [{ id: 's1' }, { id: 's2' }]));
+
+      await playlistLibraryStore.getState().fetchAllPlaylistsWithSongs();
+
+      expect(ensureCoverArtAuth).toHaveBeenCalled();
+      const state = playlistLibraryStore.getState();
+      expect(state.playlists).toHaveLength(1);
+      expect(state.loading).toBe(false);
+      expect(state.lastFetchedAt).toBeGreaterThan(0);
+
+      const playlistWithSongs = state.playlists[0] as PlaylistWithSongs;
+
+      expect(playlistWithSongs).toBeDefined();
+      expect(playlistWithSongs.entry).toBeDefined();
+      if (playlistWithSongs.entry)
+        expect(playlistWithSongs.entry.length).toBe(2)
+      
     });
 
     it('prevents duplicate fetches', async () => {

--- a/src/store/layoutPreferencesStore.ts
+++ b/src/store/layoutPreferencesStore.ts
@@ -8,6 +8,7 @@ export type AlbumSortOrder = 'artist' | 'title';
 export type ArtistAlbumSortOrder = 'newest' | 'oldest';
 export type DateFormat = 'yyyy/mm/dd' | 'yyyy/dd/mm';
 export type ListLength = 20 | 30 | 50 | 100;
+export type ShowSongInPlaylist = 'show' | 'hide';
 
 export const LIST_LENGTH_DISPLAY_CAP = 20;
 
@@ -23,6 +24,7 @@ export interface LayoutPreferencesState {
   dateFormat: DateFormat;
   listLength: ListLength;
   includePartialInDownloadedFilter: boolean;
+  showSongInPlaylist: ShowSongInPlaylist;
   setAlbumLayout: (layout: ItemLayout) => void;
   setArtistLayout: (layout: ItemLayout) => void;
   setPlaylistLayout: (layout: ItemLayout) => void;
@@ -34,6 +36,7 @@ export interface LayoutPreferencesState {
   setDateFormat: (format: DateFormat) => void;
   setListLength: (length: ListLength) => void;
   setIncludePartialInDownloadedFilter: (value: boolean) => void;
+  setShowSongInPlaylist: (option: ShowSongInPlaylist) => void;
 }
 
 const PERSIST_KEY = 'substreamer-layout-preferences';
@@ -52,6 +55,7 @@ export const layoutPreferencesStore = create<LayoutPreferencesState>()(
       dateFormat: 'yyyy/mm/dd',
       listLength: 20,
       includePartialInDownloadedFilter: false,
+      showSongInPlaylist: 'hide',
       setAlbumLayout: (albumLayout) => set({ albumLayout }),
       setArtistLayout: (artistLayout) => set({ artistLayout }),
       setPlaylistLayout: (playlistLayout) => set({ playlistLayout }),
@@ -65,6 +69,7 @@ export const layoutPreferencesStore = create<LayoutPreferencesState>()(
       setListLength: (listLength) => set({ listLength }),
       setIncludePartialInDownloadedFilter: (includePartialInDownloadedFilter) =>
         set({ includePartialInDownloadedFilter }),
+      setShowSongInPlaylist: (showSongInPlaylist) => set({ showSongInPlaylist }),
     }),
     {
       name: PERSIST_KEY,

--- a/src/store/playlistLibraryStore.ts
+++ b/src/store/playlistLibraryStore.ts
@@ -8,6 +8,8 @@ import { kvStorage } from './persistence';
 import {
   ensureCoverArtAuth,
   getAllPlaylists,
+  getPlaylist,
+  PlaylistWithSongs,
   type Playlist,
 } from '../services/subsonicService';
 
@@ -26,7 +28,7 @@ export function registerPlaylistLibraryReconcileHook(
 
 export interface PlaylistLibraryState {
   /** All playlists in the user's library */
-  playlists: Playlist[];
+  playlists: (Playlist | PlaylistWithSongs)[];
   /** Whether a fetch is currently in progress */
   loading: boolean;
   /** Last error message, if any */
@@ -36,6 +38,10 @@ export interface PlaylistLibraryState {
 
   /** Fetch all playlists from the server via getPlaylists. */
   fetchAllPlaylists: () => Promise<void>;
+
+  /** Fetch all playlists with their songs from the server via getPlaylists and getPlaylist. */
+  fetchAllPlaylistsWithSongs: () => Promise<void>;
+
   /** Remove a single playlist from the library by ID. */
   removePlaylist: (id: string) => void;
   /** Clear all playlist data */
@@ -49,6 +55,7 @@ export const playlistLibraryStore = create<PlaylistLibraryState>()(
     (set, get) => ({
       playlists: [],
       loading: false,
+      entriesLoading: false,
       error: null,
       lastFetchedAt: null,
 
@@ -81,6 +88,36 @@ export const playlistLibraryStore = create<PlaylistLibraryState>()(
             error: e instanceof Error ? e.message : i18n.t('failedToLoadPlaylists'),
           });
         }
+      },
+
+      fetchAllPlaylistsWithSongs: async () => {
+        await get().fetchAllPlaylists();
+
+        if (get().loading) return;
+
+        set({ loading: true, error: null });
+
+        try {
+
+          const playlistPromises = get().playlists.map(async (playlist) => {
+            const playlistWithEntries = await getPlaylist(playlist.id);
+            return playlistWithEntries || playlist;
+          });
+
+          const newPlaylists = await Promise.all(playlistPromises);
+
+          set({
+            loading: false,
+            playlists: newPlaylists,
+          });
+
+        } catch (e) {
+          set({
+            loading: false,
+            error: e instanceof Error ? e.message : i18n.t('failedToLoadPlaylistsEntries'),
+          });
+        }
+
       },
 
       removePlaylist: (id) =>


### PR DESCRIPTION
## Summary

This is a feature proposal.

The feature is to see which playlists a song already belongs to before adding it again. This helps users manage duplicates and organize their library more effectively. 

This feature is OFF by default to minimize network overhead for users with large libraries.

## Changes
- **I18n:** Added translation entries for the new setting and display labels.
- **Library Store:** Added `fetchAllPlaylistsWithSongs` to `PlaylistLibraryStore`. This method fetches full details for all playlists to build a local map of song IDs.
- **Settings:** Added "Show if song is in playlist" option under **Appearance and Layout**.
- **UI:** 
  - Updated `AddToPlaylistSheet` to conditionally fetch detailed playlist data.
  - Implemented `numberOfMatch` to determine number of times a song is in a playlist.
  - Added visual indicators in the AddToPlaylist menu showing the occurrence count.
- **Test:** Added a test for fetchAllPlaylistsWithSongs.

## Concerns

- All the translations are in english. Should the translations be automatically translated or left for later translation ?

- Did not fully understand the 80% + coverage requirements for the tests, is the added test enough ? 

## Testing

- [ X] `npx tsc --noEmit` passes
- [ X] `npx jest --no-coverage` passes
- [ X] New/updated tests added (if applicable)
- [ ] Tested on iOS
- [ X] Tested on Android

## Related Issues

Closes N/A (Feature Request)
