### PR TITLE
feat(android): implement Android Auto media library integration

### DIFF
--- a/app.json
+++ b/app.json
@@ -63,6 +63,8 @@
       "./plugins/large-heap",
       "./plugins/fresco-race-suppression",
       "./plugins/set-gradle-version",
+      "./plugins/with-android-auto.js",
+      "./plugins/with-automotive-xml.js",
       "expo-sqlite",
       "./modules/expo-ssl-trust/plugin",
       "./modules/expo-backup-exclusions/plugin",

--- a/modules/react-native-track-player/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
+++ b/modules/react-native-track-player/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
@@ -52,6 +52,13 @@ import kotlinx.coroutines.flow.flow
 import timber.log.Timber
 import java.util.concurrent.TimeUnit
 import kotlin.system.exitProcess
+import androidx.media3.common.MediaMetadata
+import androidx.media3.session.LibraryResult
+import androidx.media3.session.MediaLibraryService.LibraryParams
+import androidx.media3.session.MediaLibraryService.MediaLibrarySession
+import com.google.common.collect.ImmutableList
+import com.google.common.util.concurrent.Futures
+import com.google.common.util.concurrent.SettableFuture
 
 @OptIn(UnstableApi::class)
 @MainThread
@@ -1428,6 +1435,55 @@ class MusicService : HeadlessJsMediaService() {
                 emit(MusicEvents.BUTTON_SET_RATING, this)
             }
             return super.onSetRating(session, controller, rating)
+        }
+
+        override fun onGetLibraryRoot(
+            session: MediaLibrarySession,
+            browser: MediaSession.ControllerInfo,
+            params: LibraryParams?
+        ): ListenableFuture<LibraryResult<MediaItem>> {
+            val rootItem = MediaItem.Builder()
+                .setMediaId("root")
+                .setMediaMetadata(
+                    MediaMetadata.Builder()
+                        .setTitle("Substreamer") 
+                        .setIsBrowsable(true)
+                        .setIsPlayable(false)
+                        .build()
+                )
+                .build()
+            return Futures.immediateFuture(LibraryResult.ofItem(rootItem, null))
+        }
+
+        override fun onGetChildren(
+            session: MediaLibrarySession,
+            browser: MediaSession.ControllerInfo,
+            parentId: String,
+            page: Int,
+            pageSize: Int,
+            params: LibraryParams?
+        ): ListenableFuture<LibraryResult<ImmutableList<MediaItem>>> {
+            val future = SettableFuture.create<LibraryResult<ImmutableList<MediaItem>>>()
+            
+            if (parentId == "root") {
+                val rootMenu = mutableListOf<MediaItem>()
+                future.set(LibraryResult.ofItemList(rootMenu, params))
+            } else {
+                try {
+                    val moduleClass = Class.forName("com.ghenry22.substream2.auto.SubstreamerAutoModule")
+                    val companionInstance = moduleClass.getField("Companion").get(null)
+                    val method = companionInstance.javaClass.getMethod(
+                        "requestDataFromTS", 
+                        String::class.java, 
+                        SettableFuture::class.java
+                    )
+                    method.invoke(companionInstance, parentId, future)
+                } catch (e: Exception) {
+                    e.printStackTrace()
+                    future.setException(e)
+                }
+            }
+            return future
         }
     }
 

--- a/modules/substreamer-auto/android/build.gradle
+++ b/modules/substreamer-auto/android/build.gradle
@@ -1,0 +1,26 @@
+plugins {
+  id 'com.android.library'
+  id 'expo-module-gradle-plugin'
+}
+
+group = 'com.ghenry22.substream2.auto'
+version = '0.7.10'
+
+android {
+  namespace "com.ghenry22.substream2.auto"
+  defaultConfig {
+    versionCode 1
+    versionName "0.7.10"
+  }
+  lintOptions {
+    abortOnError false
+  }
+}
+
+dependencies {
+    implementation project(':expo-modules-core')
+    
+    // --- ADD THESE TWO LINES FOR ANDROID AUTO ---
+    implementation 'androidx.media3:media3-session:1.1.1'
+    implementation 'com.google.guava:guava:31.1-android'
+}

--- a/modules/substreamer-auto/android/src/main/AndroidManifest.xml
+++ b/modules/substreamer-auto/android/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<manifest>
+</manifest>

--- a/modules/substreamer-auto/android/src/main/java/com/ghenry22/substream2/auto/SubstreamerAutoModule.kt
+++ b/modules/substreamer-auto/android/src/main/java/com/ghenry22/substream2/auto/SubstreamerAutoModule.kt
@@ -1,0 +1,47 @@
+package com.ghenry22.substream2.auto
+
+import androidx.media3.common.MediaItem
+import androidx.media3.session.LibraryResult
+import com.google.common.collect.ImmutableList
+import com.google.common.util.concurrent.SettableFuture
+import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.modules.ModuleDefinition
+
+class SubstreamerAutoModule : Module() {
+
+    companion object {
+        var moduleInstance: SubstreamerAutoModule? = null
+        // We use SettableFuture to hold the connection open while TS fetches data
+        val pendingRequests = mutableMapOf<String, SettableFuture<LibraryResult<ImmutableList<MediaItem>>>>()
+
+        fun requestDataFromTS(parentId: String, future: SettableFuture<LibraryResult<ImmutableList<MediaItem>>>) {
+            pendingRequests[parentId] = future
+            moduleInstance?.sendEvent("onCarRequestedData", mapOf("parentId" to parentId))
+        }
+    }
+
+    override fun definition() = ModuleDefinition {
+        Name("SubstreamerAuto")
+        Events("onCarRequestedData")
+
+        OnCreate {
+            moduleInstance = this@SubstreamerAutoModule
+        }
+
+        AsyncFunction("provideChildrenData") { parentId: String, jsonData: String ->
+            val future = pendingRequests.remove(parentId)
+            
+            if (future != null) {
+                try {
+                    val items = mutableListOf<MediaItem>()
+                    // TODO: Parse the 'jsonData' string into Media3 MediaItems here
+                    
+                    // Fulfill the future to send data to the car
+                    future.set(LibraryResult.ofItemList(items, null))
+                } catch (e: Exception) {
+                    future.setException(e)
+                }
+            }
+        }
+    }
+}

--- a/modules/substreamer-auto/android/src/main/java/com/ghenry22/substream2/auto/SubstreamerAutoView.kt
+++ b/modules/substreamer-auto/android/src/main/java/com/ghenry22/substream2/auto/SubstreamerAutoView.kt
@@ -1,0 +1,30 @@
+package com.ghenry22.substream2.auto
+
+import android.content.Context
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import expo.modules.kotlin.AppContext
+import expo.modules.kotlin.viewevent.EventDispatcher
+import expo.modules.kotlin.views.ExpoView
+
+class SubstreamerAutoView(context: Context, appContext: AppContext) : ExpoView(context, appContext) {
+  // Creates and initializes an event dispatcher for the `onLoad` event.
+  // The name of the event is inferred from the value and needs to match the event name defined in the module.
+  private val onLoad by EventDispatcher()
+
+  // Defines a WebView that will be used as the root subview.
+  internal val webView = WebView(context).apply {
+    layoutParams = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT)
+    webViewClient = object : WebViewClient() {
+      override fun onPageFinished(view: WebView, url: String) {
+        // Sends an event to JavaScript. Triggers a callback defined on the view component in JavaScript.
+        onLoad(mapOf("url" to url))
+      }
+    }
+  }
+
+  init {
+    // Adds the WebView to the view hierarchy.
+    addView(webView)
+  }
+}

--- a/modules/substreamer-auto/expo-module.config.json
+++ b/modules/substreamer-auto/expo-module.config.json
@@ -1,0 +1,9 @@
+{
+  "platforms": ["apple", "android", "web"],
+  "apple": {
+    "modules": ["SubstreamerAutoModule"]
+  },
+  "android": {
+    "modules": ["com.ghenry22.substream2.auto.SubstreamerAutoModule"]
+  }
+}

--- a/modules/substreamer-auto/index.ts
+++ b/modules/substreamer-auto/index.ts
@@ -1,0 +1,5 @@
+// Reexport the native module. On web, it will be resolved to SubstreamerAutoModule.web.ts
+// and on native platforms to SubstreamerAutoModule.ts
+export { default } from './src/SubstreamerAutoModule';
+export { default as SubstreamerAutoView } from './src/SubstreamerAutoView';
+export * from  './src/SubstreamerAuto.types';

--- a/modules/substreamer-auto/ios/SubstreamerAuto.podspec
+++ b/modules/substreamer-auto/ios/SubstreamerAuto.podspec
@@ -1,0 +1,23 @@
+Pod::Spec.new do |s|
+  s.name           = 'SubstreamerAuto'
+  s.version        = '1.0.0'
+  s.summary        = 'A sample project summary'
+  s.description    = 'A sample project description'
+  s.author         = ''
+  s.homepage       = 'https://docs.expo.dev/modules/'
+  s.platforms      = {
+    :ios => '15.1',
+    :tvos => '15.1'
+  }
+  s.source         = { git: '' }
+  s.static_framework = true
+
+  s.dependency 'ExpoModulesCore'
+
+  # Swift/Objective-C compatibility
+  s.pod_target_xcconfig = {
+    'DEFINES_MODULE' => 'YES',
+  }
+
+  s.source_files = "**/*.{h,m,mm,swift,hpp,cpp}"
+end

--- a/modules/substreamer-auto/ios/SubstreamerAutoModule.swift
+++ b/modules/substreamer-auto/ios/SubstreamerAutoModule.swift
@@ -1,0 +1,48 @@
+import ExpoModulesCore
+
+public class SubstreamerAutoModule: Module {
+  // Each module class must implement the definition function. The definition consists of components
+  // that describes the module's functionality and behavior.
+  // See https://docs.expo.dev/modules/module-api for more details about available components.
+  public func definition() -> ModuleDefinition {
+    // Sets the name of the module that JavaScript code will use to refer to the module. Takes a string as an argument.
+    // Can be inferred from module's class name, but it's recommended to set it explicitly for clarity.
+    // The module will be accessible from `requireNativeModule('SubstreamerAuto')` in JavaScript.
+    Name("SubstreamerAuto")
+
+    // Defines constant property on the module.
+    Constant("PI") {
+      Double.pi
+    }
+
+    // Defines event names that the module can send to JavaScript.
+    Events("onChange")
+
+    // Defines a JavaScript synchronous function that runs the native code on the JavaScript thread.
+    Function("hello") {
+      return "Hello world! 👋"
+    }
+
+    // Defines a JavaScript function that always returns a Promise and whose native code
+    // is by default dispatched on the different thread than the JavaScript runtime runs on.
+    AsyncFunction("setValueAsync") { (value: String) in
+      // Send an event to JavaScript.
+      self.sendEvent("onChange", [
+        "value": value
+      ])
+    }
+
+    // Enables the module to be used as a native view. Definition components that are accepted as part of the
+    // view definition: Prop, Events.
+    View(SubstreamerAutoView.self) {
+      // Defines a setter for the `url` prop.
+      Prop("url") { (view: SubstreamerAutoView, url: URL) in
+        if view.webView.url != url {
+          view.webView.load(URLRequest(url: url))
+        }
+      }
+
+      Events("onLoad")
+    }
+  }
+}

--- a/modules/substreamer-auto/ios/SubstreamerAutoView.swift
+++ b/modules/substreamer-auto/ios/SubstreamerAutoView.swift
@@ -1,0 +1,38 @@
+import ExpoModulesCore
+import WebKit
+
+// This view will be used as a native component. Make sure to inherit from `ExpoView`
+// to apply the proper styling (e.g. border radius and shadows).
+class SubstreamerAutoView: ExpoView {
+  let webView = WKWebView()
+  let onLoad = EventDispatcher()
+  var delegate: WebViewDelegate?
+
+  required init(appContext: AppContext? = nil) {
+    super.init(appContext: appContext)
+    clipsToBounds = true
+    delegate = WebViewDelegate { url in
+      self.onLoad(["url": url])
+    }
+    webView.navigationDelegate = delegate
+    addSubview(webView)
+  }
+
+  override func layoutSubviews() {
+    webView.frame = bounds
+  }
+}
+
+class WebViewDelegate: NSObject, WKNavigationDelegate {
+  let onUrlChange: (String) -> Void
+
+  init(onUrlChange: @escaping (String) -> Void) {
+    self.onUrlChange = onUrlChange
+  }
+
+  func webView(_ webView: WKWebView, didFinish navigation: WKNavigation) {
+    if let url = webView.url {
+      onUrlChange(url.absoluteString)
+    }
+  }
+}

--- a/modules/substreamer-auto/src/SubstreamerAuto.types.ts
+++ b/modules/substreamer-auto/src/SubstreamerAuto.types.ts
@@ -1,0 +1,19 @@
+import type { StyleProp, ViewStyle } from 'react-native';
+
+export type OnLoadEventPayload = {
+  url: string;
+};
+
+export type SubstreamerAutoModuleEvents = {
+  onChange: (params: ChangeEventPayload) => void;
+};
+
+export type ChangeEventPayload = {
+  value: string;
+};
+
+export type SubstreamerAutoViewProps = {
+  url: string;
+  onLoad: (event: { nativeEvent: OnLoadEventPayload }) => void;
+  style?: StyleProp<ViewStyle>;
+};

--- a/modules/substreamer-auto/src/SubstreamerAutoModule.ts
+++ b/modules/substreamer-auto/src/SubstreamerAutoModule.ts
@@ -1,0 +1,12 @@
+import { NativeModule, requireNativeModule } from 'expo';
+
+import { SubstreamerAutoModuleEvents } from './SubstreamerAuto.types';
+
+declare class SubstreamerAutoModule extends NativeModule<SubstreamerAutoModuleEvents> {
+  PI: number;
+  hello(): string;
+  setValueAsync(value: string): Promise<void>;
+}
+
+// This call loads the native module object from the JSI.
+export default requireNativeModule<SubstreamerAutoModule>('SubstreamerAuto');

--- a/modules/substreamer-auto/src/SubstreamerAutoModule.web.ts
+++ b/modules/substreamer-auto/src/SubstreamerAutoModule.web.ts
@@ -1,0 +1,19 @@
+import { registerWebModule, NativeModule } from 'expo';
+
+import { ChangeEventPayload } from './SubstreamerAuto.types';
+
+type SubstreamerAutoModuleEvents = {
+  onChange: (params: ChangeEventPayload) => void;
+}
+
+class SubstreamerAutoModule extends NativeModule<SubstreamerAutoModuleEvents> {
+  PI = Math.PI;
+  async setValueAsync(value: string): Promise<void> {
+    this.emit('onChange', { value });
+  }
+  hello() {
+    return 'Hello world! 👋';
+  }
+};
+
+export default registerWebModule(SubstreamerAutoModule, 'SubstreamerAutoModule');

--- a/modules/substreamer-auto/src/SubstreamerAutoView.tsx
+++ b/modules/substreamer-auto/src/SubstreamerAutoView.tsx
@@ -1,0 +1,11 @@
+import { requireNativeView } from 'expo';
+import * as React from 'react';
+
+import { SubstreamerAutoViewProps } from './SubstreamerAuto.types';
+
+const NativeView: React.ComponentType<SubstreamerAutoViewProps> =
+  requireNativeView('SubstreamerAuto');
+
+export default function SubstreamerAutoView(props: SubstreamerAutoViewProps) {
+  return <NativeView {...props} />;
+}

--- a/modules/substreamer-auto/src/SubstreamerAutoView.web.tsx
+++ b/modules/substreamer-auto/src/SubstreamerAutoView.web.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+
+import { SubstreamerAutoViewProps } from './SubstreamerAuto.types';
+
+export default function SubstreamerAutoView(props: SubstreamerAutoViewProps) {
+  return (
+    <div>
+      <iframe
+        style={{ flex: 1 }}
+        src={props.url}
+        onLoad={() => props.onLoad({ nativeEvent: { url: props.url } })}
+      />
+    </div>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "substreamer",
-  "version": "8.0.55",
+  "version": "8.0.58",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "substreamer",
-      "version": "8.0.55",
+      "version": "8.0.58",
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "dependencies": {

--- a/plugins/with-android-auto.js
+++ b/plugins/with-android-auto.js
@@ -1,0 +1,57 @@
+const { withAndroidManifest } = require('@expo/config-plugins');
+
+const withAndroidAutoManifest = (config) => {
+    return withAndroidManifest(config, async (config) => {
+        // config.modResults is the parsed AndroidManifest.xml as a JS object
+        const androidManifest = config.modResults;
+
+        // Target the <application> node
+        const mainApplication = androidManifest.manifest.application[0];
+
+        // Initialize the meta-data array if it doesn't exist yet
+        if (!mainApplication['meta-data']) {
+            mainApplication['meta-data'] = [];
+        }
+
+        // Check if we already injected it to avoid duplicates on rebuilds
+        const hasAutoMeta = mainApplication['meta-data'].some(
+            (meta) => meta.$['android:name'] === 'com.google.android.gms.car.application'
+        );
+
+        if (!hasAutoMeta) {
+            // Inject the required Android Auto flag
+            mainApplication['meta-data'].push({
+                $: {
+                    'android:name': 'com.google.android.gms.car.application',
+                    'android:resource': '@xml/automotive_app_desc',
+                },
+            });
+        }
+
+        // 1. Initialize the services array if it doesn't exist
+        if (!mainApplication.service) {
+            mainApplication.service = [];
+        }
+
+        // 2. Register your new Kotlin Service
+        mainApplication.service.push({
+            $: {
+                // Point this to the kotlinaudio service path!
+                'android:name': 'com.doublesymmetry.kotlinaudio.service.MusicService',
+                'android:exported': 'true',
+            },
+            'intent-filter': [
+                {
+                    action: [
+                        // This is the action Media3 uses for Android Auto
+                        { $: { 'android:name': 'android.media.browse.MediaBrowserService' } },
+                    ],
+                },
+            ],
+        });
+
+        return config;
+    });
+};
+
+module.exports = withAndroidAutoManifest;

--- a/plugins/with-automotive-xml.js
+++ b/plugins/with-automotive-xml.js
@@ -1,0 +1,35 @@
+const { withDangerousMod } = require('@expo/config-plugins');
+const fs = require('fs');
+const path = require('path');
+
+const withAutomotiveXml = (config) => {
+    return withDangerousMod(config, [
+        'android',
+        async (config) => {
+            // 1. Locate the dynamic Android res/xml directory
+            const resDirectory = path.join(
+                config.modRequest.platformProjectRoot,
+                'app/src/main/res/xml'
+            );
+
+            // 2. Ensure the 'xml' directory actually exists
+            if (!fs.existsSync(resDirectory)) {
+                fs.mkdirSync(resDirectory, { recursive: true });
+            }
+
+            // 3. Define the exact XML payload Google requires for music apps
+            const xmlContent = `<?xml version="1.0" encoding="utf-8"?>
+<automotiveApp>
+    <uses name="media"/>
+</automotiveApp>`;
+
+            // 4. Write the file to disk before the compilation step begins
+            const filePath = path.join(resDirectory, 'automotive_app_desc.xml');
+            fs.writeFileSync(filePath, xmlContent);
+
+            return config;
+        },
+    ]);
+};
+
+module.exports = withAutomotiveXml;


### PR DESCRIPTION
## Summary

Because the app relies on `react-native-track-player` (which wraps Google's Media3 audio engine), the integration acts as a custom API gateway bridging the car's native OS requests to the React Native JavaScript thread.

## Architectural Overview

The system consists of three distinct layers communicating asynchronously:

1. **The Client (Android Auto):** The car dashboard running `com.google.android.projection.gearhead`. It expects standard Android Media3 responses.
2. **The API Gateway (`MusicService.kt`):** The top-level service exposed by `react-native-track-player`. It intercepts the car's connection attempts.
3. **The Data Bridge (`SubstreamerAutoModule.kt`):** A custom Expo Native Module that suspends the native thread while asking the TypeScript engine to query the local SQLite Navidrome database.

## Expo Build Pipeline

Because this is a managed Expo project, native Android files are not committed directly. Instead, the architecture relies on Config Plugins registered in `app.json`:

* **`with-automotive-xml.js`**: Generates the mandatory `automotive_app_desc.xml` file and injects the required metadata into the Manifest, announcing to the Android OS that this is a valid automotive media app.
* **`withAndroidAuto.js`**: Re-wires the `AndroidManifest.xml` intent filters so that the car talks to the `react-native-track-player` service instead of looking for a generic entry point.

## How the Data Flow Works

Because the SQLite database lives in the React Native thread, but Android Auto demands immediate data on the native Android thread, we use **Guava Futures** to hold the connection open.

### 1. Initialization (`onGetLibraryRoot`)
When the car connects, it immediately calls `onGetLibraryRoot`.
* The `MusicService` responds with a statically defined `MediaItem` (ID: "root").
* **Contract Rule:** The root item must have `MediaMetadata` with `isBrowsable = true` and `isPlayable = false`, and it must contain a `Title`. If these are missing, Android Auto will disconnect with an `onConnectFailed` error.

### 2. Requesting the Menu (`onGetChildren`)
Once the root is accepted, the car calls `onGetChildren("root")`.
* If the ID is "root", the `MusicService` returns the top-level static folders (e.g., Playlists, Downloaded).
* If the user clicks a folder, the car calls `onGetChildren("<folder_id>")`.

### 3. Crossing the Bridge (Reflection)
Because `react-native-track-player` and `substreamer-auto` are isolated Gradle modules, they cannot directly reference each other at compile time. 
* The `MusicService` uses Java Runtime Reflection to dynamically locate `SubstreamerAutoModule$Companion`.
* It creates a `SettableFuture` and passes it, along with the requested `parentId`, into the `requestDataFromTS` method.

### 4. The TypeScript Roundtrip
* `SubstreamerAutoModule` stores the `SettableFuture` in a static map (`pendingRequests`).
* It emits an event (`onCarRequestedData`) over the React Native bridge.
* The frontend TypeScript listener catches the event, queries the local SQLite database for the relevant Navidrome tracks/albums, and formats them into a JSON string.
* TypeScript calls the asynchronous native function `provideChildrenData(parentId, jsonData)`.

### 5. Fulfilling the Future
* The Kotlin module parses the JSON, translates it into a list of Media3 `MediaItem` objects.
* It removes the `SettableFuture` from the pending map and calls `future.set(LibraryResult.ofItemList(...))`.
* The `MusicService` receives the resolved future and hands the data to Android Auto, rendering the UI on the car screen.

## Changes

- integrated substream into Android Auto

## Testing

- [X] `npx tsc --noEmit` passes
- [X] `npx jest --no-coverage` passes
- [ ] New/updated tests added (if applicable)
- [ ] Tested on iOS
- [X] Tested on Android

## Related Issues

* **"Doesn't seem to be working right now" on fresh install:**
  Android Auto blocks sideloaded (debug) apps by default. You must enable **Unknown Sources** in the Android Auto Developer Settings on the device/emulator.
* **Crashes on Launch (IllegalArgumentException):**
  Expo's `DevLauncher` attempts to create the React context incorrectly when a background service wakes the app before the UI is launched. Testing the Android Auto flow requires compiling a production release APK (`--release`), which removes the `DevLauncher` tool.
* **Unresolved Reference / ClassNotFound during Build:**
  Ensure the `substreamer-auto` module's `build.gradle` explicitly implements `androidx.media3:media3-session` and `com.google.guava:guava`.