### PR TITLE
Add iOS local network permission description

### DIFF
--- a/app.json
+++ b/app.json
@@ -23,6 +23,7 @@
           "NSAllowsArbitraryLoads": true
         },
         "ITSAppUsesNonExemptEncryption": false,
+        "NSLocalNetworkUsageDescription": "Substreamer uses your local network to connect to your self-hosted music server.",
         "NSLocationWhenInUseUsageDescription": "Location access is needed to detect your WiFi network name for automatic offline mode switching.",
         "INAlternativeAppNames": [
           {


### PR DESCRIPTION
## What changed

- add `NSLocalNetworkUsageDescription` to the Expo-managed iOS Info.plist configuration

## Why

iOS requires this usage description before an app can prompt for permission to connect to LAN hosts. Without it, Substreamer does not appear under **Settings > Privacy & Security > Local Network**, and direct connections to self-hosted music servers can fail.

## Validation

- confirmed Expo config introspection includes the usage description in the generated iOS Info.plist
- `npx tsc --noEmit`
- `npx jest --no-coverage --no-watchman`
