### PR TITLE
Add multiple artists support

### DIFF
--- a/src/components/ArtistLink.tsx
+++ b/src/components/ArtistLink.tsx
@@ -1,0 +1,61 @@
+import { memo } from 'react';
+import { Pressable, StyleSheet, Text } from 'react-native';
+import { useRouter } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+import { useTheme } from '@/hooks/useTheme';
+
+type ArtistLinkProps = {
+  artistId: string;
+  artistName: string;
+  offline: boolean;
+  fontSize?: number;
+};
+
+const ArtistLink = memo(function ArtistLink({
+  artistId,
+  artistName,
+  offline,
+  fontSize,
+}: ArtistLinkProps) {
+  const { colors } = useTheme();
+  const { t } = useTranslation();
+  const router = useRouter();
+
+  const text = (
+    <Text
+      style={[
+        styles.artistText,
+        { color: colors.textSecondary },
+        fontSize ? { fontSize } : undefined,
+      ]}
+      numberOfLines={1}
+    >
+      {artistName}
+    </Text>
+  );
+
+  if (offline) return text;
+
+  return (
+    <Pressable
+      onPress={() => router.push(`/artist/${artistId}`)}
+      hitSlop={8}
+      accessibilityRole="button"
+      accessibilityLabel={t('goToArtist')}
+      style={({ pressed }) => pressed && styles.pressed}
+    >
+      {text}
+    </Pressable>
+  );
+});
+
+const styles = StyleSheet.create({
+  artistText: {
+    fontSize: 16,
+  },
+  pressed: {
+    opacity: 0.6,
+  },
+});
+
+export default ArtistLink;

--- a/src/components/MoreOptionsSheet.tsx
+++ b/src/components/MoreOptionsSheet.tsx
@@ -47,6 +47,7 @@ import {
   deletePlaylist,
   isVariousArtists,
   type AlbumID3,
+  type ArtistID3,
   type Child,
   type Playlist,
 } from '../services/subsonicService';
@@ -114,8 +115,8 @@ function isStarrable(entity: MoreOptionsEntity): boolean {
 }
 
 function hasArtistLink(entity: MoreOptionsEntity): boolean {
-  if (entity.type === 'song') return Boolean(entity.item.artistId);
-  if (entity.type === 'album') return Boolean(entity.item.artistId);
+  if (entity.type === 'song') return Boolean(entity.item.artistId) || Boolean((entity.item as Child).artists?.length);
+  if (entity.type === 'album') return Boolean(entity.item.artistId) || Boolean((entity.item as AlbumID3).artists?.length);
   return false;
 }
 
@@ -303,8 +304,10 @@ export function MoreOptionsSheet() {
   const [detailsVisible, setDetailsVisible] = useState(false);
   const [detailsAlbum, setDetailsAlbum] = useState<AlbumID3 | null>(null);
   const [detailsTrack, setDetailsTrack] = useState<Child | null>(null);
+  const [pickerArtists, setPickerArtists] = useState<ArtistID3[] | null>(null);
 
   const handleClose = useCallback(() => {
+    setPickerArtists(null);
     hide();
   }, [hide]);
 
@@ -418,20 +421,50 @@ export function MoreOptionsSheet() {
 
   const handleGoToArtist = useCallback(() => {
     if (!entity) return;
+
+    const artists = entity.type === 'song'
+      ? (entity.item as Child).artists
+      : entity.type === 'album'
+        ? (entity.item as AlbumID3).artists
+        : undefined;
+
+    // Multiple artists → drill into a picker page inside this same sheet
+    // (kept in the one Modal so the handoff is instant, no re-open animation).
+    if (artists && artists.length > 1) {
+      setPickerArtists(artists);
+      return;
+    }
+
     handleClose();
     if (source === 'player-tablet-landscape') {
       tabletLayoutStore.getState().setPlayerExpanded(false);
     }
+    // Prefer the single entry in the artists array; fall back to the legacy
+    // artistId field for servers that only populate it.
     const artistId =
-      entity.type === 'song'
+      artists?.[0]?.id ??
+      (entity.type === 'song'
         ? (entity.item as Child).artistId
         : entity.type === 'album'
           ? (entity.item as AlbumID3).artistId
-          : undefined;
+          : undefined);
     if (artistId) {
       router.push(`/artist/${artistId}`);
     }
   }, [entity, handleClose, source, router]);
+
+  const handleArtistPicked = useCallback((artistId: string) => {
+    setPickerArtists(null);
+    handleClose();
+    if (source === 'player-tablet-landscape') {
+      tabletLayoutStore.getState().setPlayerExpanded(false);
+    }
+    router.push(`/artist/${artistId}`);
+  }, [handleClose, source, router]);
+
+  const handleArtistPickerBack = useCallback(() => {
+    setPickerArtists(null);
+  }, []);
 
   const handleGoToAlbum = useCallback(() => {
     if (!entity || entity.type !== 'song') return;
@@ -684,7 +717,36 @@ export function MoreOptionsSheet() {
         onClose={handleClose}
         onCloseComplete={() => moreOptionsStore.getState()._signalCloseComplete()}
       >
-          {isPlayerSource && showAddQueueToPlaylist && (
+          {pickerArtists ? (
+            <>
+              {/* Multi-artist picker — drill-down page inside the same sheet */}
+              <MoreOptionsRow
+                icon={<Ionicons name="arrow-back" size={22} color={colors.textPrimary} style={styles.optionIcon} />}
+                label={t('back')}
+                onPress={handleArtistPickerBack}
+              />
+
+              <View style={styles.sectionDivider} />
+
+              <Text
+                style={[styles.sheetTitle, { color: colors.textPrimary }]}
+                numberOfLines={1}
+              >
+                {t('selectArtist')}
+              </Text>
+
+              {pickerArtists.map((artist) => (
+                <MoreOptionsRow
+                  key={artist.id}
+                  icon={<Ionicons name="person-outline" size={22} color={colors.textPrimary} style={styles.optionIcon} />}
+                  label={artist.name}
+                  onPress={() => handleArtistPicked(artist.id)}
+                />
+              ))}
+            </>
+          ) : (
+            <>
+            {isPlayerSource && showAddQueueToPlaylist && (
             <>
               {/* Player Queue: add the whole queue to a playlist, then a divider
                   before the per-entity options below. */}
@@ -973,6 +1035,8 @@ export function MoreOptionsSheet() {
                 />
               )}
             </>
+          </>
+          )}
       </BottomSheet>
 
       {detailsAlbum && (

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -691,6 +691,7 @@
   "addToQueue": "Add to Queue",
   "goToAlbum": "Go to Album",
   "goToArtist": "Go to Artist",
+  "selectArtist": "Select Artist",
   "share": "Share",
   "copy": "Copy",
   "edit": "Edit",

--- a/src/screens/album-detail.tsx
+++ b/src/screens/album-detail.tsx
@@ -1,5 +1,5 @@
 import { Stack, useLocalSearchParams, useNavigation, useRouter } from 'expo-router';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Fragment, useCallback, useEffect, useMemo, useState } from 'react';
 import {
   ActivityIndicator,
   Platform,
@@ -15,6 +15,7 @@ import { LIST_DRAW_DISTANCE } from '../constants/layout';
 import { useTranslation } from 'react-i18next';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
+import ArtistLink from '../components/ArtistLink';
 import { CachedImage } from '../components/CachedImage';
 import { EmptyState } from '../components/EmptyState';
 import { DownloadButton } from '../components/DownloadButton';
@@ -233,18 +234,29 @@ export function AlbumDetailScreen() {
           </MarqueeText>
           <View style={styles.subtitleRow}>
             <View style={styles.subtitleText}>
-              {album.artistId && !offlineMode ? (
-                <Pressable
-                  onPress={() => router.push(`/artist/${album.artistId}`)}
-                  hitSlop={8}
-                  accessibilityRole="button"
-                  accessibilityLabel={t('goToArtist')}
-                  style={({ pressed }) => pressed && styles.artistNamePressed}
-                >
-                  <Text style={[styles.artistName, { color: colors.textSecondary }]}>
-                    {album.artist ?? album.displayArtist ?? t('unknownArtist')}
-                  </Text>
-                </Pressable>
+              {album.artists && album.artists.length > 0 ? (
+                <View style={{ flexDirection: 'row', flexWrap: 'wrap' }}>
+                  {album.artists.map((artist, i, arr) => (
+                    <Fragment key={artist.id}>
+                      <ArtistLink
+                        artistId={artist.id}
+                        artistName={artist.name}
+                        offline={offlineMode}
+                      />
+                      {i < arr.length - 1 && (
+                        <Text style={[styles.artistName, { color: colors.textSecondary }]}>
+                          {' · '}
+                        </Text>
+                      )}
+                    </Fragment>
+                  ))}
+                </View>
+              ) : album.artistId ? (
+                <ArtistLink
+                  artistId={album.artistId}
+                  artistName={album.artist ?? album.displayArtist ?? t('unknownArtist')}
+                  offline={offlineMode}
+                />
               ) : (
                 <Text style={[styles.artistName, { color: colors.textSecondary }]}>
                   {album.artist ?? album.displayArtist ?? t('unknownArtist')}
@@ -436,9 +448,6 @@ const styles = StyleSheet.create({
   },
   artistName: {
     fontSize: 16,
-  },
-  artistNamePressed: {
-    opacity: 0.6,
   },
   trackItemWrap: {
     // No padding here — TrackRow now provides 16px internal horizontal

--- a/src/screens/artist-detail.tsx
+++ b/src/screens/artist-detail.tsx
@@ -260,12 +260,14 @@ export function ArtistDetailScreen() {
           </View>
         </View>
         <View style={styles.heroButtons}>
-          <PillToggle
-            options={playModeOptions}
-            selected={artistPlayMode}
-            onSelect={handlePlayModeChange}
-            colors={colors}
-          />
+          {topSongs.length > 0 && (
+            <PillToggle
+              options={playModeOptions}
+              selected={artistPlayMode}
+              onSelect={handlePlayModeChange}
+              colors={colors}
+            />
+          )}
           <View style={styles.heroPlayButtons}>
             <ShufflePlayButton
               onPress={() => {
@@ -549,7 +551,7 @@ const styles = StyleSheet.create({
   heroButtons: {
     flexDirection: 'row',
     alignItems: 'center',
-    justifyContent: 'space-between',
+    justifyContent: 'flex-end',
     paddingHorizontal: 16,
   },
   heroPlayButtons: {

--- a/src/screens/artist-detail.tsx
+++ b/src/screens/artist-detail.tsx
@@ -164,7 +164,17 @@ export function ArtistDetailScreen() {
 
   /* ---- Derived values ---- */
   const albums = artist?.album ?? [];
-  const similarArtists = artistInfo?.similarArtist ?? [];
+  // Deduplicate by id — some backends (e.g. Navidrome) can return the same
+  // artist multiple times in similarArtist, which causes visible gaps when
+  // FlashList allocates space for the duplicate but React skips rendering it.
+  const similarArtists = useMemo(() => {
+    const seen = new Set<string>();
+    return (artistInfo?.similarArtist ?? []).filter((a) => {
+      if (seen.has(a.id)) return false;
+      seen.add(a.id);
+      return true;
+    });
+  }, [artistInfo?.similarArtist]);
 
   const sortedAlbums = useMemo(() => {
     if (albums.length === 0) return albums;

--- a/src/screens/player/player-phone-portrait.tsx
+++ b/src/screens/player/player-phone-portrait.tsx
@@ -2,7 +2,7 @@ import Ionicons from "@react-native-vector-icons/ionicons/static";
 import { FlashList } from '@shopify/flash-list';
 import { Stack, useNavigation, useRouter } from 'expo-router';
 import { LinearGradient } from 'expo-linear-gradient';
-import { memo, useCallback, useEffect, useMemo, useState } from 'react';
+import { Fragment, memo, useCallback, useEffect, useMemo, useState } from 'react';
 import {
   ActivityIndicator,
   Platform,
@@ -24,6 +24,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
 
 import { AlbumInfoContent } from '@/components/AlbumInfoContent';
+import ArtistLink from '@/components/ArtistLink';
 import { LyricsContent } from '@/components/LyricsContent';
 import { BookmarkButton } from '@/components/BookmarkButton';
 import { CachedImage } from '@/components/CachedImage';
@@ -437,6 +438,8 @@ const PlayerContent = memo(function PlayerContent({
   shuffling,
 }: PlayerContentProps) {
   const { t } = useTranslation();
+  const router = useRouter();
+  const offlineMode = offlineModeStore((s) => s.offlineMode);
   const songCoverArtId = useSongCoverArt(currentTrack);
   const { height: windowHeight, width: windowWidth } = useWindowDimensions();
   const insets = useSafeAreaInsets();
@@ -534,12 +537,36 @@ const PlayerContent = memo(function PlayerContent({
             <MarqueeText style={marqueeStyle}>
               {currentTrack.title}
             </MarqueeText>
-            <Text
-              style={[styles.trackArtist, { color: colors.textSecondary, fontSize: m.artistFont }]}
-              numberOfLines={1}
-            >
-              {currentTrack.artist ?? t('unknownArtist')}
-            </Text>
+            {currentTrack.artists && currentTrack.artists.length > 0 ? (
+              <View style={{ flexDirection: 'row', flexWrap: 'wrap' }}>
+                {currentTrack.artists.map((artist, i, arr) => (
+                  <Fragment key={artist.id}>
+                    <ArtistLink
+                      artistId={artist.id}
+                      artistName={artist.name}
+                      fontSize={m.artistFont}
+                      offline={offlineMode}
+                    />
+                    {i < arr.length - 1 && (
+                      <Text style={[styles.trackArtist, { color: colors.textSecondary, fontSize: m.artistFont }]}>
+                        {' · '}
+                      </Text>
+                    )}
+                  </Fragment>
+                ))}
+              </View>
+            ) : currentTrack.artistId ? (
+              <ArtistLink
+                artistId={currentTrack.artistId}
+                artistName={currentTrack.artist ?? t('unknownArtist')}
+                fontSize={m.artistFont}
+                offline={offlineMode}
+              />
+            ) : (
+              <Text style={[styles.trackArtist, { color: colors.textSecondary, fontSize: m.artistFont }]} numberOfLines={1}>
+                {currentTrack.artist ?? t('unknownArtist')}
+              </Text>
+            )}
             <CastButton />
           </View>
           <FavoriteButton trackId={currentTrack.id} style={styles.favoriteButton} />

--- a/src/screens/player/player-tablet-portrait.tsx
+++ b/src/screens/player/player-tablet-portrait.tsx
@@ -2,7 +2,7 @@ import Ionicons from "@react-native-vector-icons/ionicons/static";
 import MaterialCommunityIcons from "@react-native-vector-icons/material-design-icons/static";
 import { Stack, useNavigation, useRouter } from 'expo-router';
 import { LinearGradient } from 'expo-linear-gradient';
-import { memo, useCallback, useEffect, useMemo, useState } from 'react';
+import { Fragment, memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   ActivityIndicator,
@@ -17,6 +17,7 @@ import { Pressable as GHPressable } from 'react-native-gesture-handler';
 import Animated, { useAnimatedStyle } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
+import ArtistLink from '@/components/ArtistLink';
 import { BookmarkButton } from '@/components/BookmarkButton';
 import { CachedImage } from '@/components/CachedImage';
 import { FavoriteButton } from '@/components/FavoriteButton';
@@ -233,9 +234,34 @@ export function PlayerTabletPortrait() {
                     <MarqueeText style={[styles.trackTitle, { color: colors.textPrimary }]}>
                       {currentTrack.title}
                     </MarqueeText>
-                    <Text style={[styles.trackArtist, { color: colors.textSecondary }]} numberOfLines={1}>
-                      {currentTrack.artist ?? t('unknownArtist')}
-                    </Text>
+                    {currentTrack.artists && currentTrack.artists.length > 0 ? (
+                      <View style={{ flexDirection: 'row', flexWrap: 'wrap' }}>
+                        {currentTrack.artists.map((artist, i, arr) => (
+                          <Fragment key={artist.id}>
+                            <ArtistLink
+                              artistId={artist.id}
+                              artistName={artist.name}
+                              offline={offlineMode}
+                            />
+                            {i < arr.length - 1 && (
+                              <Text style={[styles.trackArtist, { color: colors.textSecondary }]}>
+                                {' · '}
+                              </Text>
+                            )}
+                          </Fragment>
+                        ))}
+                      </View>
+                    ) : currentTrack.artistId ? (
+                      <ArtistLink
+                        artistId={currentTrack.artistId}
+                        artistName={currentTrack.artist ?? t('unknownArtist')}
+                        offline={offlineMode}
+                      />
+                    ) : (
+                      <Text style={[styles.trackArtist, { color: colors.textSecondary }]} numberOfLines={1}>
+                        {currentTrack.artist ?? t('unknownArtist')}
+                      </Text>
+                    )}
                     <CastButton />
                   </View>
                   <FavoriteButton trackId={currentTrack.id} style={styles.favoriteButton} />


### PR DESCRIPTION
I noticed songs and albums with multiple artists didn't surface the secondary artists anywhere, so I added support for that, plus a couple of small fixes I came across on the artist detail page. I tried to stay consistent with the existing patterns in the repo, but happy to adjust anything if you'd prefer it done differently.

Changes: 
-  Tappable artist links — when a song or album has multiple artists, they now appear as inline, tappable links (separated by ·) each jumping straight to that artist's page

-  "Go to Artist" picker — if a song/album has more than one artist, the more-options sheet now shows an in-sheet "Select Artist" picker with a back button instead of silently picking the first artist. Single-artist cases behave exactly as before.

-  Artist detail cleanup — dedupes the similar-artists list (Navidrome can return the same artist more than once, which left gaps in the list), and hides the "Top songs / All songs" toggle when an artist has no top songs to switch between.


## Testing

- [ ] `npx tsc --noEmit` passes
- [ ] `npx jest --no-coverage` passes
- [ ] New/updated tests added (if applicable)
- [ ] Tested on iOS
- [ ] Tested on Android

## Related Issues

Closes #
