### PR TITLE
fix(image-cache): stop the un-decodable cover churn loop

### DIFF
--- a/src/services/__tests__/imageCacheService.test.ts
+++ b/src/services/__tests__/imageCacheService.test.ts
@@ -335,6 +335,8 @@ import {
   prefetchCoverArt,
   __resetRetryStateForTest,
   reportBadRemote,
+  reportBadCache,
+  retryRemoteImagesForServerSwitch,
   isRemoteFailed,
 } from '../imageCacheService';
 
@@ -706,6 +708,8 @@ describe('download pipeline — cacheAllSizes + processQueue', () => {
     );
     // addFile was called for the source + 3 resized variants
     expect(mockUpsertCachedImage).toHaveBeenCalled();
+    // A decoding fresh source never trips the terminal flag.
+    expect(isRemoteFailed(id)).toBe(false);
   });
 
   it('does NOT cache an HTTP-200 XML error envelope as an image', async () => {
@@ -1083,6 +1087,10 @@ describe('generateResizedVariant — 3-failure circuit breaker purges row', () =
     expect(mockDeleteCachedImagesForCoverArt).toHaveBeenCalledWith(id);
     expect(mockDbRows.has(mockDbKey(id, 600))).toBe(false);
     expect(mockFileExistsMap.get(fileMockName(id, '600.jpg'))).toBeFalsy();
+    // A CACHED source that won't decode is local-state corruption, not a
+    // server defect: the purge hands the next run a fresh download to
+    // re-evaluate — no terminal flag.
+    expect(isRemoteFailed(id)).toBe(false);
   });
 
   it('does not purge when failures stay below the threshold', async () => {
@@ -1112,6 +1120,71 @@ describe('generateResizedVariant — 3-failure circuit breaker purges row', () =
   // server simply returned the same un-decodable bytes). The retry
   // machinery + tests have been removed; CachedImage's source-size
   // fallback handles user-visible recovery instead.
+});
+
+describe('generateResizedVariant — terminal flag on a fresh source that won\'t decode', () => {
+  /** Drive a fresh (uncached) source download: no 600 row, fetch resolves. */
+  function mockFreshSourceFetch(): void {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      headers: { get: () => 'image/jpeg' },
+      arrayBuffer: () => Promise.resolve(jpegBuffer(1024)),
+    });
+  }
+
+  it('flags the id remote-failed after three strikes on a freshly downloaded source', async () => {
+    const id = 'terminal-fresh';
+    mockFreshSourceFetch();
+    mockResizeImageToFileAsync.mockRejectedValue(new Error('persistent decode failure'));
+
+    await ensureCached(id);
+
+    expect(mockResizeImageToFileAsync).toHaveBeenCalledTimes(3);
+    expect(mockDeleteCachedImagesForCoverArt).toHaveBeenCalledWith(id);
+    expect(mockDbRows.has(mockDbKey(id, 600))).toBe(false);
+    expect(isRemoteFailed(id)).toBe(true);
+  });
+
+  it('does not re-download a terminally flagged id from any enqueue path', async () => {
+    const id = 'terminal-gated';
+    mockFreshSourceFetch();
+    mockResizeImageToFileAsync.mockRejectedValue(new Error('persistent decode failure'));
+
+    await ensureCached(id);
+    expect(isRemoteFailed(id)).toBe(true);
+
+    const fetches = mockFetch.mock.calls.length;
+    // Both component-driven re-entries funnel through the cacheAllSizes gate.
+    await ensureCached(id);
+    await reportBadCache(id, 300);
+
+    expect(mockFetch.mock.calls.length).toBe(fetches);
+    expect(mockResizeImageToFileAsync).toHaveBeenCalledTimes(3);
+  });
+
+  it('re-arms the download path once the flag is cleared', async () => {
+    const id = 'terminal-recovery';
+    mockFreshSourceFetch();
+    mockResizeImageToFileAsync.mockRejectedValue(new Error('persistent decode failure'));
+
+    await ensureCached(id);
+    expect(isRemoteFailed(id)).toBe(true);
+
+    // Server switch / recovery paths clear the set on purpose.
+    retryRemoteImagesForServerSwitch();
+    expect(isRemoteFailed(id)).toBe(false);
+
+    mockFetch.mockClear();
+    mockResizeImageToFileAsync.mockClear();
+    mockFreshSourceFetch();
+    mockResizeImageToFileAsync.mockRejectedValue(new Error('persistent decode failure'));
+    await ensureCached(id);
+
+    // One more bounded attempt — re-terminates if the server still serves
+    // the bad bytes, but the cycle no longer self-sustains.
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(isRemoteFailed(id)).toBe(true);
+  });
 });
 
 describe('listCachedImages — file names from DB row shape', () => {

--- a/src/services/imageCacheService.ts
+++ b/src/services/imageCacheService.ts
@@ -1209,6 +1209,15 @@ async function cacheAllSizes(coverArtId: string): Promise<void> {
   // their coverArtId to `undefined` before calling here.
   if (isSentinelCoverArtId(coverArtId)) return;
 
+  // Remote-failed ids (server error, or a source that won't decode) park on
+  // the placeholder — this gate stops the render→report→re-enqueue cycle
+  // churning the network on them. Recovery is explicit and clears the set on
+  // purpose: server switch, offline→online, app foreground, manual refresh.
+  if (failedRemoteIds.has(coverArtId)) {
+    logImageCache(`cacheAllSizes id=${coverArtId} remote-failed-skip`);
+    return;
+  }
+
   // DB is the source of truth for "is this cover complete?" — never the
   // in-memory cache (which raced the boot index-build and skipped variants).
   const cachedSizes = await cachedSizesForCover(coverArtId);
@@ -1292,10 +1301,17 @@ export async function reportBadRemote(coverArtId: string): Promise<void> {
   }
   if (failedRemoteIds.has(coverArtId)) return;
   logImageCache(`reportBadRemote id=${coverArtId}`);
+  flagRemoteFailed(coverArtId);
+}
+
+/**
+ * Add the id to `failedRemoteIds` and notify its subscribers directly —
+ * bypassing `notifyImageCacheUpdate`, whose "fresh variant landed" branch
+ * would delete the flag we just set. Idempotent: a repeat call is a no-op.
+ */
+function flagRemoteFailed(coverArtId: string): void {
+  if (failedRemoteIds.has(coverArtId)) return;
   failedRemoteIds.add(coverArtId);
-  // Notify subscribers directly — bypass `notifyImageCacheUpdate` so the
-  // helper's "delete from failedRemoteIds" branch doesn't undo what we
-  // just did.
   const listeners = cacheUpdateListeners.get(coverArtId);
   if (!listeners) return;
   for (const listener of listeners) {
@@ -1527,7 +1543,7 @@ async function downloadAndCacheImage(coverArtId: string): Promise<void> {
     `downloadAndCacheImage id=${coverArtId} resize-needed=[${needed.join(',')}] source-cached=${sourceWasCached}`,
   );
   for (const size of needed) {
-    await generateResizedVariant(source600Uri, coverArtId, size, subDir);
+    await generateResizedVariant(source600Uri, coverArtId, size, subDir, sourceWasCached);
   }
 }
 
@@ -1714,7 +1730,9 @@ async function downloadSourceImage(
  * devices). On the threshold strike, the row is purged: source bytes
  * are most likely corrupt or in an unsupported format, and re-running
  * the same decode would just re-fail. Counter resets on success or
- * after a purge so a fresh download can be evaluated cleanly.
+ * after a purge so a fresh download can be evaluated cleanly; when the
+ * purged source was itself a fresh download, the id is additionally
+ * flagged remote-failed, because re-fetching would return the same bytes.
  */
 const variantFailureCount = new Map<string, number>();
 const MAX_VARIANT_FAILURES = 3;
@@ -1726,12 +1744,17 @@ const MAX_VARIANT_FAILURES = 3;
  * `UIImage(contentsOfFile:)` (iOS) — no Glide, no coroutine callback
  * surface, so the `expo-image-manipulator` double-resume crash that
  * surfaces on Android 16 is structurally impossible here.
+ *
+ * `sourceWasCached` distinguishes a stale local copy (its purge hands the
+ * next run a fresh download to re-evaluate) from bytes the server just
+ * served (a threshold strike on those is terminal — see the catch block).
  */
 async function generateResizedVariant(
   sourceUri: string,
   coverArtId: string,
   size: number,
   subDir: Directory,
+  sourceWasCached: boolean,
 ): Promise<void> {
   const fileName = `${size}.jpg`;
   const tmpName = `${fileName}.tmp`;
@@ -1804,13 +1827,18 @@ async function generateResizedVariant(
       );
       logImageCache(`resize id=${coverArtId} threshold-purge`);
       await purgeCoverArtRows(coverArtId);
-      // No further server-side recovery is attempted. The Subsonic spec
-      // for `getCoverArt` accepts only `id` and `size`, so a `format=jpg`
-      // query is a no-op — the server returns the same un-decodable
-      // bytes. User-visible recovery is handled
-      // upstream in CachedImage's source-size fallback, which renders
-      // the (decodable) 600 source in the smaller slot when smaller
-      // variants are unavailable.
+      // A source that was freshly downloaded from the server in this run
+      // and still won't decode is a server-side defect: re-fetching returns
+      // the same bytes, so no further server-side recovery is possible.
+      // Flag the id remote-failed — CachedImage parks on the placeholder,
+      // the cacheAllSizes gate stops the re-download, and the standard
+      // recovery paths (server switch, offline→online, foreground, manual
+      // refresh) un-stick it. A stale local copy is NOT flagged: its purge
+      // hands the next run a fresh download to re-evaluate.
+      if (!sourceWasCached) {
+        logImageCache(`resize id=${coverArtId} terminal remote-failed`);
+        flagRemoteFailed(coverArtId);
+      }
     }
   }
 }


### PR DESCRIPTION
A server that deterministically serves an un-decodable cover source drove a ~20 Hz download → 3 resize fails → threshold-purge → re-render the fresh 600 via source-fallback → reportBadCache → re-enqueue cycle for as long as the cover was on screen. Sustained network + CPU + IO overheated the device until the OS killed the app.

The 3-strike threshold purge already reset its own budget on the assumption a fresh download would re-evaluate cleanly — false when the server re-serves the same bad bytes, so the purge was a loop reset, not a terminal state. The render→report→re-enqueue path bypassed the bounded scheduleRetry ladder entirely, which is why it never decayed.

Now: when the strike-3 source was freshly downloaded in that run (sourceWasCached === false), the id is additionally flagged remote- failed. CachedImage parks on the placeholder, and a new gate in cacheAllSizes (the single chokepoint for ensureCached, reportBadCache, scheduleRetry, prefetchCoverArt and repair) stops the re-download. The stale-local-copy case is NOT flagged — its purge still hands the next run a fresh download to re-evaluate, preserving the self-heal. Recovery reuses the existing clearing paths (server switch, offline→online, foreground, manual refresh) via a shared flagRemoteFailed helper.

## Summary

Brief description of what this PR does and why.

## Changes

-

## Testing

- [x] `npx tsc --noEmit` passes
- [x] `npx jest --no-coverage` passes
- [x] New/updated tests added (if applicable)
- [ ] Tested on iOS <--- nope, sorry I don't even have disk space on my only non-work related mac to install xcode
- [ ] Tested on Android <--- nope, only iphones in this household

## Related Issues

Closes #291 
